### PR TITLE
Properly name the root field execution functions

### DIFF
--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -135,7 +135,7 @@ export interface ExecutionArgs {
  * a GraphQLError will be thrown immediately explaining the invalid input.
  */
 export function execute(args: ExecutionArgs): PromiseOrValue<ExecutionResult> {
-  const { schema, document, variableValues, rootValue } = args;
+  const { schema, document, variableValues } = args;
 
   // If arguments are missing or incorrect, throw an error.
   assertValidExecutionArguments(schema, document, variableValues);
@@ -149,9 +149,9 @@ export function execute(args: ExecutionArgs): PromiseOrValue<ExecutionResult> {
     return { errors: exeContext };
   }
 
-  // Return a Promise that will eventually resolve to the data described by
-  // The "Response" section of the GraphQL specification.
-  //
+  // Return data or a  Promise that will eventually resolve to the data described
+  // by the "Response" section of the GraphQL specification.
+
   // If errors are encountered while executing a GraphQL field, only that
   // field and its descendants will be omitted, and sibling fields will still
   // be executed. An execution which encounters errors will still result in a
@@ -161,8 +161,7 @@ export function execute(args: ExecutionArgs): PromiseOrValue<ExecutionResult> {
   // at which point we still log the error and null the parent field, which
   // in this case is the entire response.
   try {
-    const { operation } = exeContext;
-    const result = executeOperation(exeContext, operation, rootValue);
+    const result = executeQueryOrMutationRootFields(exeContext);
     if (isPromise(result)) {
       return result.then(
         (data) => buildResponse(data, exeContext.errors),
@@ -312,15 +311,15 @@ export function buildExecutionContext(
 }
 
 /**
- * Implements the "Executing operations" section of the spec.
+ * Executes the root fields specified by query or mutation operation.
  */
-function executeOperation(
+function executeQueryOrMutationRootFields(
   exeContext: ExecutionContext,
-  operation: OperationDefinitionNode,
-  rootValue: unknown,
 ): PromiseOrValue<ObjMap<unknown> | null> {
+  const { schema, operation, rootValue } = exeContext;
+
   // TODO: replace getOperationRootType with schema.getRootType
-  const rootType = getOperationRootType(exeContext.schema, operation);
+  const rootType = getOperationRootType(schema, operation);
   /* if (rootType == null) {
     throw new GraphQLError(
       `Schema is not configured to execute ${operation.operation} operation.`,

--- a/src/execution/subscribe.ts
+++ b/src/execution/subscribe.ts
@@ -154,7 +154,7 @@ export async function createSourceEventStream(
   }
 
   try {
-    const eventStream = await executeSubscription(exeContext);
+    const eventStream = await executeSubscriptionRootField(exeContext);
 
     // Assert field returned an event stream, otherwise yield an error.
     if (!isAsyncIterable(eventStream)) {
@@ -175,7 +175,7 @@ export async function createSourceEventStream(
   }
 }
 
-async function executeSubscription(
+async function executeSubscriptionRootField(
   exeContext: ExecutionContext,
 ): Promise<unknown> {
   const { schema, fragments, operation, variableValues, rootValue } =


### PR DESCRIPTION
The codebase should refer to functions that execute the query, mutation, and/or subscription root fields as such, rather than as functions that execute the operations themselves. Executing a query or mutation returns a map of data and errors, while executing the root fields returns the data of the root fields.