### PR TITLE
Subscriptions should normalize requests only once

### DIFF
--- a/src/execution/__tests__/subscribe-test.ts
+++ b/src/execution/__tests__/subscribe-test.ts
@@ -523,8 +523,7 @@ describe('Subscription Initialization Phase', () => {
 
     // If we receive variables that cannot be coerced correctly, subscribe() will
     // resolve to an ExecutionResult that contains an informative error description.
-    const result = await subscribe({ schema, document, variableValues });
-    expectJSON(result).toDeepEqual({
+    const expectedResult = {
       errors: [
         {
           message:
@@ -532,7 +531,21 @@ describe('Subscription Initialization Phase', () => {
           locations: [{ line: 2, column: 21 }],
         },
       ],
-    });
+    };
+
+    expectJSON(
+      await subscribe({ schema, document, variableValues }),
+    ).toDeepEqual(expectedResult);
+
+    expectJSON(
+      await createSourceEventStream(
+        schema,
+        document,
+        undefined,
+        undefined,
+        variableValues,
+      ),
+    ).toDeepEqual(expectedResult);
   });
 });
 

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -156,7 +156,11 @@ export function execute(args: ExecutionArgs): PromiseOrValue<ExecutionResult> {
     return { errors: exeContext };
   }
 
-  // Return data or a  Promise that will eventually resolve to the data described
+  return executeQueryOrMutation(exeContext);
+}
+
+export function executeQueryOrMutation(exeContext: ExecutionContext) {
+  // Return data or a Promise that will eventually resolve to the data described
   // by the "Response" section of the GraphQL specification.
 
   // If errors are encountered while executing a GraphQL field, only that

--- a/src/execution/subscribe.ts
+++ b/src/execution/subscribe.ts
@@ -19,7 +19,7 @@ import {
   assertValidExecutionArguments,
   buildExecutionContext,
   buildResolveInfo,
-  execute,
+  executeQueryOrMutation,
   getFieldDef,
 } from './execute';
 
@@ -49,26 +49,28 @@ import { mapAsyncIterator } from './mapAsyncIterator';
 export async function subscribe(
   args: ExecutionArgs,
 ): Promise<AsyncGenerator<ExecutionResult, void, void> | ExecutionResult> {
-  const {
-    schema,
-    document,
-    rootValue,
-    contextValue,
-    variableValues,
-    operationName,
-    fieldResolver,
-    subscribeFieldResolver,
-  } = args;
+  const { schema, document, variableValues } = args;
 
-  const resultOrStream = await createSourceEventStream(
-    schema,
-    document,
-    rootValue,
-    contextValue,
-    variableValues,
-    operationName,
-    subscribeFieldResolver,
-  );
+  // If arguments are missing or incorrectly typed, this is an internal
+  // developer mistake which should throw an early error.
+  assertValidExecutionArguments(schema, document, variableValues);
+
+  // If a valid execution context cannot be created due to incorrect arguments,
+  // a "Response" with only errors is returned.
+  const exeContext = buildExecutionContext(args);
+
+  // Return early errors if execution context failed.
+  if (!('schema' in exeContext)) {
+    return { errors: exeContext };
+  }
+
+  return executeSubscription(exeContext);
+}
+
+async function executeSubscription(
+  exeContext: ExecutionContext,
+): Promise<AsyncGenerator<ExecutionResult, void, void> | ExecutionResult> {
+  const resultOrStream = await createSourceEventStreamImpl(exeContext);
 
   if (!isAsyncIterable(resultOrStream)) {
     return resultOrStream;
@@ -81,14 +83,10 @@ export async function subscribe(
   // "ExecuteSubscriptionEvent" algorithm, as it is nearly identical to the
   // "ExecuteQuery" algorithm, for which `execute` is also used.
   const mapSourceToResponse = (payload: unknown) =>
-    execute({
-      schema,
-      document,
+    executeQueryOrMutation({
+      ...exeContext,
       rootValue: payload,
-      contextValue,
-      variableValues,
-      operationName,
-      fieldResolver,
+      errors: [],
     });
 
   // Map every source value to a ExecutionResult value as described above.
@@ -153,6 +151,12 @@ export async function createSourceEventStream(
     return { errors: exeContext };
   }
 
+  return createSourceEventStreamImpl(exeContext);
+}
+
+export async function createSourceEventStreamImpl(
+  exeContext: ExecutionContext,
+): Promise<AsyncIterable<unknown> | ExecutionResult> {
   try {
     const eventStream = await executeSubscriptionRootField(exeContext);
 


### PR DESCRIPTION
The `subscribe` method calls `createSourceEventStream` and `execute`, each of which normalize the request properties separately. By normalizing requests within the `subscribe` function, we can pass the normalized arguments to the implementation for `createSourceEventStream` and `execute`, i.e. new functions `createSourceEventStreamImpl` and `executeQueryOrMutation`.