### PR TITLE
Move call site for assertValidExecutionArguments

### DIFF
--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -135,11 +135,6 @@ export interface ExecutionArgs {
  * a GraphQLError will be thrown immediately explaining the invalid input.
  */
 export function execute(args: ExecutionArgs): PromiseOrValue<ExecutionResult> {
-  const { schema, document, variableValues } = args;
-
-  // If arguments are missing or incorrect, throw an error.
-  assertValidExecutionArguments(schema, document, variableValues);
-
   // If a valid execution context cannot be created due to incorrect arguments,
   // a "Response" with only errors is returned.
   const exeContext = buildExecutionContext(args);
@@ -212,10 +207,8 @@ function buildResponse(
 /**
  * Essential assertions before executing to provide developer feedback for
  * improper use of the GraphQL library.
- *
- * @internal
  */
-export function assertValidExecutionArguments(
+function assertValidExecutionArguments(
   schema: GraphQLSchema,
   document: DocumentNode,
   rawVariableValues: Maybe<{ readonly [variable: string]: unknown }>,
@@ -254,6 +247,10 @@ export function buildExecutionContext(
     typeResolver,
     subscribeFieldResolver,
   } = args;
+
+  // If arguments are missing or incorrectly typed, this is an internal
+  // developer mistake which should throw an error.
+  assertValidExecutionArguments(schema, document, rawVariableValues);
 
   let operation: OperationDefinitionNode | undefined;
   const fragments: ObjMap<FragmentDefinitionNode> = Object.create(null);

--- a/src/execution/subscribe.ts
+++ b/src/execution/subscribe.ts
@@ -16,7 +16,6 @@ import type { ExecutionArgs, ExecutionContext } from './execute';
 import { collectFields } from './collectFields';
 import { getArgumentValues } from './values';
 import {
-  assertValidExecutionArguments,
   buildExecutionContext,
   buildResolveInfo,
   executeQueryOrMutation,
@@ -49,12 +48,6 @@ import { mapAsyncIterator } from './mapAsyncIterator';
 export async function subscribe(
   args: ExecutionArgs,
 ): Promise<AsyncGenerator<ExecutionResult, void, void> | ExecutionResult> {
-  const { schema, document, variableValues } = args;
-
-  // If arguments are missing or incorrectly typed, this is an internal
-  // developer mistake which should throw an early error.
-  assertValidExecutionArguments(schema, document, variableValues);
-
   // If a valid execution context cannot be created due to incorrect arguments,
   // a "Response" with only errors is returned.
   const exeContext = buildExecutionContext(args);
@@ -130,10 +123,6 @@ export async function createSourceEventStream(
   operationName?: Maybe<string>,
   subscribeFieldResolver?: Maybe<GraphQLFieldResolver<any, any>>,
 ): Promise<AsyncIterable<unknown> | ExecutionResult> {
-  // If arguments are missing or incorrectly typed, this is an internal
-  // developer mistake which should throw an early error.
-  assertValidExecutionArguments(schema, document, variableValues);
-
   // If a valid execution context cannot be created due to incorrect arguments,
   // a "Response" with only errors is returned.
   const exeContext = buildExecutionContext({


### PR DESCRIPTION
The function is used only by `buildExecutionContext` and can be called there rather than exported