### PR TITLE
add additional methods hooks

### DIFF
--- a/src/execution/__tests__/nonnull-test.ts
+++ b/src/execution/__tests__/nonnull-test.ts
@@ -106,6 +106,7 @@ const schema = buildSchema(`
 
   schema {
     query: DataType
+    mutation: DataType
   }
 `);
 
@@ -490,39 +491,63 @@ describe('Execute: handles non-nullable types', () => {
     });
   });
 
-  describe('nulls the top level if non-nullable field', () => {
-    const query = `
-      {
-        syncNonNull
-      }
-    `;
+  describe('nulls the top level', () => {
+    const nullingDataResult = {
+      data: null,
+      errors: [
+        {
+          message:
+            'Cannot return null for non-nullable field DataType.syncNonNull.',
+          path: ['syncNonNull'],
+          locations: [{ line: 3, column: 11 }],
+        },
+      ],
+    };
 
-    it('that returns null', async () => {
-      const result = await executeSyncAndAsync(query, nullingData);
-      expectJSON(result).toDeepEqual({
-        data: null,
-        errors: [
-          {
-            message:
-              'Cannot return null for non-nullable field DataType.syncNonNull.',
-            path: ['syncNonNull'],
-            locations: [{ line: 3, column: 9 }],
-          },
-        ],
+    const throwingDataResult = {
+      data: null,
+      errors: [
+        {
+          message: syncNonNullError.message,
+          path: ['syncNonNull'],
+          locations: [{ line: 3, column: 11 }],
+        },
+      ],
+    };
+
+    describe('for queries, if non-nullable field', () => {
+      const query = `
+        {
+          syncNonNull
+        }
+      `;
+
+      it('that returns null', async () => {
+        const result = await executeSyncAndAsync(query, nullingData);
+        expectJSON(result).toDeepEqual(nullingDataResult);
+      });
+
+      it('that throws', async () => {
+        const result = await executeSyncAndAsync(query, throwingData);
+        expectJSON(result).toDeepEqual(throwingDataResult);
       });
     });
 
-    it('that throws', async () => {
-      const result = await executeSyncAndAsync(query, throwingData);
-      expectJSON(result).toDeepEqual({
-        data: null,
-        errors: [
-          {
-            message: syncNonNullError.message,
-            path: ['syncNonNull'],
-            locations: [{ line: 3, column: 9 }],
-          },
-        ],
+    describe('for mutations, if non-nullable field', () => {
+      const mutation = `
+        mutation {
+          syncNonNull
+        }
+      `;
+
+      it('that returns null', async () => {
+        const result = await executeSyncAndAsync(mutation, nullingData);
+        expectJSON(result).toDeepEqual(nullingDataResult);
+      });
+
+      it('that throws', async () => {
+        const result = await executeSyncAndAsync(mutation, throwingData);
+        expectJSON(result).toDeepEqual(throwingDataResult);
       });
     });
   });

--- a/src/execution/executor.ts
+++ b/src/execution/executor.ts
@@ -302,13 +302,16 @@ export class Executor {
    * at which point we still log the error and null the parent field, which
    * in this case is the entire response.
    */
-   executeQueryAlgorithm(
+  executeQueryAlgorithm(
     exeContext: ExecutionContext,
   ): PromiseOrValue<
     | ExecutionResult
     | AsyncGenerator<ExecutionResult | AsyncExecutionResult, void, void>
   > {
-    return this.executeQueryOrMutationImpl(exeContext, this.executeFields.bind(this));
+    return this.executeQueryOrMutationImpl(
+      exeContext,
+      this.executeFields.bind(this),
+    );
   }
 
   /**
@@ -321,7 +324,10 @@ export class Executor {
     | ExecutionResult
     | AsyncGenerator<ExecutionResult | AsyncExecutionResult, void, void>
   > {
-    return this.executeQueryOrMutationImpl(exeContext, this.executeFieldsSerially.bind(this));
+    return this.executeQueryOrMutationImpl(
+      exeContext,
+      this.executeFieldsSerially.bind(this),
+    );
   }
 
   /**

--- a/src/execution/executor.ts
+++ b/src/execution/executor.ts
@@ -255,16 +255,34 @@ export class Executor {
   > {
     const { operation, forceQueryAlgorithm } = exeContext;
 
-    if (operation.operation === 'subscription' && !forceQueryAlgorithm) {
-      return this.executeSubscriptionImpl(exeContext);
+    if (forceQueryAlgorithm) {
+      return this.executeQueryAlgorithm(exeContext);
     }
 
-    return this.executeQueryOrMutationImpl(exeContext);
+    const operationType = operation.operation;
+    switch (operationType) {
+      case 'query':
+        return this.executeQueryImpl(exeContext);
+      case 'mutation':
+        return this.executeMutationImpl(exeContext);
+      default:
+        return this.executeSubscriptionImpl(exeContext);
+    }
+  }
+
+  executeQueryImpl(
+    exeContext: ExecutionContext,
+  ): PromiseOrValue<
+    | ExecutionResult
+    | AsyncGenerator<ExecutionResult | AsyncExecutionResult, void, void>
+  > {
+    return this.executeQueryAlgorithm(exeContext);
   }
 
   /**
-   * Return data or a Promise that will eventually resolve to the data described
-   * by the "Response" section of the GraphQL specification.
+   * Implements the ExecuteQuery algorithm described in the GraphQL
+   * specification. This algorithm is used to execute query operations
+   * and to implement the ExecuteSubscriptionEvent algorith,
    *
    * If errors are encountered while executing a GraphQL field, only that
    * field and its descendants will be omitted, and sibling fields will still
@@ -275,7 +293,7 @@ export class Executor {
    * at which point we still log the error and null the parent field, which
    * in this case is the entire response.
    */
-  executeQueryOrMutationImpl(
+  executeQueryAlgorithm(
     exeContext: ExecutionContext,
   ): PromiseOrValue<
     | ExecutionResult
@@ -284,7 +302,39 @@ export class Executor {
     let data: PromiseOrValue<ObjMap<unknown> | null>;
 
     try {
-      data = this.executeQueryOrMutationRootFields(exeContext);
+      data = this.executeRootFields(exeContext);
+    } catch (error) {
+      exeContext.errors.push(error);
+      return this.buildResponse(exeContext, null);
+    }
+
+    if (isPromise(data)) {
+      return data.then(
+        (resolvedData) => this.buildResponse(exeContext, resolvedData),
+        (error) => {
+          exeContext.errors.push(error);
+          return this.buildResponse(exeContext, null);
+        },
+      );
+    }
+
+    return this.buildResponse(exeContext, data);
+  }
+
+  /**
+   * Implements the ExecuteMutation algorithm described in the Graphql
+   * specification.
+   */
+  executeMutationImpl(
+    exeContext: ExecutionContext,
+  ): PromiseOrValue<
+    | ExecutionResult
+    | AsyncGenerator<ExecutionResult | AsyncExecutionResult, void, void>
+  > {
+    let data: PromiseOrValue<ObjMap<unknown> | null>;
+
+    try {
+      data = this.executeRootFieldsSerially(exeContext);
     } catch (error) {
       exeContext.errors.push(error);
       return this.buildResponse(exeContext, null);
@@ -459,9 +509,9 @@ export class Executor {
   }
 
   /**
-   * Executes the root fields specified by query or mutation operation.
+   * Executes the root fields specified by the operation.
    */
-  executeQueryOrMutationRootFields(
+  executeRootFields(
     exeContext: ExecutionContext,
   ): PromiseOrValue<ObjMap<unknown> | null> {
     const {
@@ -486,40 +536,55 @@ export class Executor {
     );
     const path = undefined;
 
-    let result;
-    switch (operation.operation) {
-      // TODO: Change 'query', etc. => to OperationTypeNode.QUERY, etc. when upstream
-      // graphql-js properly exports OperationTypeNode as a value.
-      case 'query':
-        result = this.executeFields(
-          exeContext,
-          rootType,
-          rootValue,
-          path,
-          fields,
-          errors,
-        );
-        break;
-      case 'mutation':
-        result = this.executeFieldsSerially(
-          exeContext,
-          rootType,
-          rootValue,
-          path,
-          fields,
-        );
-        break;
-      default:
-        // Temporary solution until we finish merging execute and subscribe together
-        result = this.executeFields(
-          exeContext,
-          rootType,
-          rootValue,
-          path,
-          fields,
-          errors,
-        );
-    }
+    const result = this.executeFields(
+      exeContext,
+      rootType,
+      rootValue,
+      path,
+      fields,
+      errors,
+    );
+
+    this.executePatches(exeContext, patches, rootType, rootValue, path);
+
+    return result;
+  }
+
+  /**
+   * Executes the root fields specified by the operation serially,
+   * as appropriate for a mutation operation.
+   */
+  executeRootFieldsSerially(
+    exeContext: ExecutionContext,
+  ): PromiseOrValue<ObjMap<unknown> | null> {
+    const {
+      schema,
+      fragments,
+      rootValue,
+      operation,
+      variableValues,
+      disableIncremental,
+    } = exeContext;
+
+    const {
+      rootType,
+      fieldsAndPatches: { fields, patches },
+    } = this.parseOperationRoot(
+      schema,
+      fragments,
+      variableValues,
+      operation,
+      disableIncremental,
+    );
+    const path = undefined;
+
+    const result = this.executeFieldsSerially(
+      exeContext,
+      rootType,
+      rootValue,
+      path,
+      fields,
+    );
 
     this.executePatches(exeContext, patches, rootType, rootValue, path);
 
@@ -1460,7 +1525,7 @@ export class Executor {
         exeContext,
         payload,
       );
-      return this.executeQueryOrMutationImpl(perPayloadExecutionContext);
+      return this.executeSubscriptionEvent(perPayloadExecutionContext);
     };
 
     // Map every source value to a ExecutionResult value as described above.
@@ -1562,6 +1627,15 @@ export class Executor {
     } catch (error) {
       throw locatedError(error, fieldNodes, pathToArray(path));
     }
+  }
+
+  executeSubscriptionEvent(
+    exeContext: ExecutionContext,
+  ): PromiseOrValue<
+    | ExecutionResult
+    | AsyncGenerator<ExecutionResult | AsyncExecutionResult, void, void>
+  > {
+    return this.executeQueryAlgorithm(exeContext);
   }
 
   hasSubsequentPayloads(exeContext: ExecutionContext) {


### PR DESCRIPTION
i.e., `executeQueryImpl`, `executeMutationImpl`, `executeQueryAlgorithm`, `executeSubscriptionEvent`, `executeRootFields`.

the addition of these functions makes the code more verbose, but reduces some redundant variable cbecking (multiple checks of operation type) and provides additional granular hooks for those wishing to subclass the Executor.