### PR TITLE
replace mapAsyncIterator with repeater implementation

### DIFF
--- a/.changeset/itchy-snails-sleep.md
+++ b/.changeset/itchy-snails-sleep.md
@@ -1,0 +1,7 @@
+---
+'graphql-executor': major
+---
+
+Refactor mapAsyncIterator to use a Repeater implementation
+
+This is a breaking change as the generator returned by mapAsyncIterator will now (correctly) not support concurrent next() and throw() calls. As the generator returned by calls to execute should rarely be used with throw(), this breaking change should have little impact.

--- a/src/execution/__tests__/simplePubSub-test.ts
+++ b/src/execution/__tests__/simplePubSub-test.ts
@@ -1,6 +1,8 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 
+import { expectPromise } from '../../__testUtils__/expectPromise';
+
 import { SimplePubSub } from './simplePubSub';
 
 describe('SimplePubSub', () => {
@@ -23,8 +25,8 @@ describe('SimplePubSub', () => {
     });
 
     // Read ahead
-    const i3 = iterator.next().then((x) => x);
-    const i4 = iterator.next().then((x) => x);
+    const i3 = iterator.next();
+    const i4 = iterator.next();
 
     // Publish
     expect(pubsub.emit('Coconut')).to.equal(true);
@@ -35,7 +37,7 @@ describe('SimplePubSub', () => {
     expect(await i3).to.deep.equal({ done: false, value: 'Coconut' });
 
     // Read ahead
-    const i5 = iterator.next().then((x) => x);
+    const i5 = iterator.next();
 
     // Terminate queue
     await iterator.return();
@@ -45,6 +47,58 @@ describe('SimplePubSub', () => {
 
     // Find that cancelled read-ahead got a "done" result
     expect(await i5).to.deep.equal({ done: true, value: undefined });
+
+    // And next returns empty completion value
+    expect(await iterator.next()).to.deep.equal({
+      done: true,
+      value: undefined,
+    });
+  });
+
+  it('allows returning early', async () => {
+    const pubsub = new SimplePubSub();
+    // istanbul ignore next (Shouldn't be reached)
+    const iterator = pubsub.getSubscriber((x) => x);
+
+    // Read ahead
+    const payload = iterator.next();
+
+    // Return early
+    expect(await iterator.return()).to.deep.equal({
+      value: undefined,
+      done: true,
+    });
+
+    // Publish is not caught after terminate
+    expect(pubsub.emit('Apple')).to.equal(false);
+
+    // Find that cancelled read-ahead got a "done" result
+    expect(await payload).to.deep.equal({ done: true, value: undefined });
+
+    // And next returns empty completion value
+    expect(await iterator.next()).to.deep.equal({
+      done: true,
+      value: undefined,
+    });
+  });
+
+  it('allows throwing into the iterator', async () => {
+    const pubsub = new SimplePubSub();
+    // istanbul ignore next (Shouldn't be reached)
+    const iterator = pubsub.getSubscriber((x) => x);
+
+    // Read ahead
+    const payload = iterator.next();
+
+    // Throw error into iterator
+    const error = new Error('allows throwing into the iterator');
+    await expectPromise(iterator.throw(error)).toRejectWith(error);
+
+    // Publish is not caught after terminate
+    expect(pubsub.emit('Apple')).to.equal(false);
+
+    // Find that cancelled read-ahead got a "done" result
+    expect(await payload).to.deep.equal({ done: true, value: undefined });
 
     // And next returns empty completion value
     expect(await iterator.next()).to.deep.equal({

--- a/src/execution/__tests__/subscribe-test.ts
+++ b/src/execution/__tests__/subscribe-test.ts
@@ -956,11 +956,23 @@ describe('Subscription Publish Phase', () => {
       },
     });
 
+    // Throw error
+    // See: https://github.com/repeaterjs/repeater/issues/72#issuecomment-963426268
+    const error = new Error('should not trigger when subscription is thrown');
+    const caughtError = subscription.throw(error).catch((e) => e);
     payload = subscription.next();
 
-    // Throw error
-    const error = new Error('should not trigger when subscription is thrown');
-    await expectPromise(subscription.throw(error)).toRejectWith(error);
+    // A new email arrives!
+    expect(
+      pubsub.emit({
+        from: 'yuzhi@graphql.org',
+        subject: 'Alright 2',
+        message: 'Tests are good 2',
+        unread: true,
+      }),
+    ).to.equal(true);
+
+    expect(await caughtError).to.equal(error);
 
     expect(await payload).to.deep.equal({
       done: true,

--- a/src/execution/mapAsyncIterator.ts
+++ b/src/execution/mapAsyncIterator.ts
@@ -1,55 +1,40 @@
+import { isPromise } from '../jsutils/isPromise';
 import type { PromiseOrValue } from '../jsutils/PromiseOrValue';
+import { Repeater } from '../jsutils/repeater';
 
 /**
  * Given an AsyncIterable and a callback function, return an AsyncIterator
  * which produces values mapped via calling the callback function.
  */
-export function mapAsyncIterator<T, U, R = undefined>(
-  iterable: AsyncGenerator<T, R, void> | AsyncIterable<T>,
-  callback: (value: T) => PromiseOrValue<U>,
-): AsyncGenerator<U, R, void> {
-  const iterator = iterable[Symbol.asyncIterator]();
+export function mapAsyncIterator<T, U>(
+  iterable: AsyncGenerator<T> | AsyncIterable<T>,
+  fn: (value: T) => PromiseOrValue<U>,
+): AsyncGenerator<U> {
+  return new Repeater(async (push, stop) => {
+    const iter = iterable[Symbol.asyncIterator]();
+    let finalIteration: PromiseOrValue<IteratorResult<T>> | undefined;
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    stop.then(() => {
+      finalIteration =
+        typeof iter.return === 'function'
+          ? iter.return()
+          : { value: undefined, done: true };
+    });
 
-  async function mapResult(
-    result: IteratorResult<T, R>,
-  ): Promise<IteratorResult<U, R>> {
-    if (result.done) {
-      return result;
+    // eslint-disable-next-line no-unmodified-loop-condition
+    while (!finalIteration) {
+      // eslint-disable-next-line no-await-in-loop
+      const iteration = await iter.next();
+      if (iteration.done) {
+        stop();
+        return iteration.value;
+      }
+      // eslint-disable-next-line no-await-in-loop
+      await push(fn(iteration.value));
     }
 
-    try {
-      return { value: await callback(result.value), done: false };
-    } catch (error) {
-      // istanbul ignore else (FIXME: add test case)
-      if (typeof iterator.return === 'function') {
-        try {
-          await iterator.return();
-        } catch (_e) {
-          /* ignore error */
-        }
-      }
-      throw error;
+    if (isPromise(finalIteration)) {
+      await finalIteration;
     }
-  }
-
-  return {
-    async next() {
-      return mapResult(await iterator.next());
-    },
-    async return(): Promise<IteratorResult<U, R>> {
-      // If iterator.return() does not exist, then type R must be undefined.
-      return typeof iterator.return === 'function'
-        ? mapResult(await iterator.return())
-        : { value: undefined as any, done: true };
-    },
-    async throw(error?: unknown) {
-      if (typeof iterator.throw === 'function') {
-        return mapResult(await iterator.throw(error));
-      }
-      throw error;
-    },
-    [Symbol.asyncIterator]() {
-      return this;
-    },
-  };
+  });
 }


### PR DESCRIPTION
This is a breaking change, because repeaters don't support concurrent next and throw calls. This should not be an issue, as throw should not generally be used with the generator returned by graphql.