### PR TITLE
Rename mapAsyncIterator to mapAsyncIterable

### DIFF
--- a/src/execution/__tests__/mapAsyncIterable-test.ts
+++ b/src/execution/__tests__/mapAsyncIterable-test.ts
@@ -3,10 +3,10 @@ import { describe, it } from 'mocha';
 
 import { expectPromise } from '../../__testUtils__/expectPromise';
 
-import { mapAsyncIterator } from '../mapAsyncIterator';
+import { mapAsyncIterable } from '../mapAsyncIterable';
 
 /* eslint-disable @typescript-eslint/require-await */
-describe('mapAsyncIterator', () => {
+describe('mapAsyncIterable', () => {
   it('maps over async generator', async () => {
     async function* source() {
       yield 1;
@@ -14,7 +14,7 @@ describe('mapAsyncIterator', () => {
       yield 3;
     }
 
-    const doubles = mapAsyncIterator(source(), (x) => x + x);
+    const doubles = mapAsyncIterable(source(), (x) => x + x);
 
     expect(await doubles.next()).to.deep.equal({ value: 2, done: false });
     expect(await doubles.next()).to.deep.equal({ value: 4, done: false });
@@ -44,7 +44,7 @@ describe('mapAsyncIterator', () => {
       },
     };
 
-    const doubles = mapAsyncIterator(iterable, (x) => x + x);
+    const doubles = mapAsyncIterable(iterable, (x) => x + x);
 
     expect(await doubles.next()).to.deep.equal({ value: 2, done: false });
     expect(await doubles.next()).to.deep.equal({ value: 4, done: false });
@@ -62,7 +62,7 @@ describe('mapAsyncIterator', () => {
       yield 3;
     }
 
-    const doubles = mapAsyncIterator(source(), (x) => x + x);
+    const doubles = mapAsyncIterable(source(), (x) => x + x);
 
     const result = [];
     for await (const x of doubles) {
@@ -78,7 +78,7 @@ describe('mapAsyncIterator', () => {
       yield 3;
     }
 
-    const doubles = mapAsyncIterator(source(), (x) => Promise.resolve(x + x));
+    const doubles = mapAsyncIterable(source(), (x) => Promise.resolve(x + x));
 
     expect(await doubles.next()).to.deep.equal({ value: 2, done: false });
     expect(await doubles.next()).to.deep.equal({ value: 4, done: false });
@@ -103,7 +103,7 @@ describe('mapAsyncIterator', () => {
       }
     }
 
-    const doubles = mapAsyncIterator(source(), (x) => x + x);
+    const doubles = mapAsyncIterable(source(), (x) => x + x);
 
     expect(await doubles.next()).to.deep.equal({ value: 2, done: false });
     expect(await doubles.next()).to.deep.equal({ value: 4, done: false });
@@ -142,7 +142,7 @@ describe('mapAsyncIterator', () => {
       },
     };
 
-    const doubles = mapAsyncIterator(iterable, (x) => x + x);
+    const doubles = mapAsyncIterable(iterable, (x) => x + x);
 
     expect(await doubles.next()).to.deep.equal({ value: 2, done: false });
     expect(await doubles.next()).to.deep.equal({ value: 4, done: false });
@@ -169,7 +169,7 @@ describe('mapAsyncIterator', () => {
       }
     }
 
-    const doubles = mapAsyncIterator(source(), (x) => x + x);
+    const doubles = mapAsyncIterable(source(), (x) => x + x);
 
     expect(await doubles.next()).to.deep.equal({ value: 'aa', done: false });
     expect(await doubles.next()).to.deep.equal({ value: 'bb', done: false });
@@ -210,7 +210,7 @@ describe('mapAsyncIterator', () => {
       },
     };
 
-    const doubles = mapAsyncIterator(iterable, (x) => x + x);
+    const doubles = mapAsyncIterable(iterable, (x) => x + x);
 
     expect(await doubles.next()).to.deep.equal({ value: 2, done: false });
     expect(await doubles.next()).to.deep.equal({ value: 4, done: false });
@@ -235,7 +235,7 @@ describe('mapAsyncIterator', () => {
       }
     }
 
-    const doubles = mapAsyncIterator(source(), (x) => x + x);
+    const doubles = mapAsyncIterable(source(), (x) => x + x);
 
     expect(await doubles.next()).to.deep.equal({ value: 2, done: false });
     expect(await doubles.next()).to.deep.equal({ value: 4, done: false });
@@ -263,7 +263,7 @@ describe('mapAsyncIterator', () => {
       throw error;
     }
 
-    const doubles = mapAsyncIterator(source(), (x) => x + x);
+    const doubles = mapAsyncIterable(source(), (x) => x + x);
 
     expect(await doubles.next()).to.deep.equal({
       value: 'HelloHello',
@@ -289,7 +289,7 @@ describe('mapAsyncIterator', () => {
       }
     }
 
-    const throwOver1 = mapAsyncIterator(source(), mapper);
+    const throwOver1 = mapAsyncIterable(source(), mapper);
 
     expect(await throwOver1.next()).to.deep.equal({ value: 1, done: false });
 

--- a/src/execution/__tests__/subscribe-test.ts
+++ b/src/execution/__tests__/subscribe-test.ts
@@ -119,7 +119,7 @@ function createSubscription(
 
   const data: any = {
     inbox: { emails },
-    // FIXME: we shouldn't use mapAsyncIterator here since it makes tests way more complex
+    // FIXME: we shouldn't use mapAsyncIterable here since it makes tests way more complex
     importantEmail: pubsub.getSubscriber((newEmail) => {
       emails.push(newEmail);
 

--- a/src/execution/executor.ts
+++ b/src/execution/executor.ts
@@ -59,7 +59,7 @@ import {
   collectFields,
   collectSubfields as _collectSubfields,
 } from './collectFields';
-import { mapAsyncIterator } from './mapAsyncIterator';
+import { mapAsyncIterable } from './mapAsyncIterable';
 import { flattenAsyncIterator } from './flattenAsyncIterator';
 
 /**
@@ -1543,7 +1543,7 @@ export class Executor {
 
     // Map every source value to a ExecutionResult value as described above.
     return flattenAsyncIterator<ExecutionResult, AsyncExecutionResult>(
-      mapAsyncIterator(resultOrStream, mapSourceToResponse),
+      mapAsyncIterable(resultOrStream, mapSourceToResponse),
     );
   }
 

--- a/src/execution/mapAsyncIterable.ts
+++ b/src/execution/mapAsyncIterable.ts
@@ -3,11 +3,11 @@ import type { PromiseOrValue } from '../jsutils/PromiseOrValue';
 import { Repeater } from '../jsutils/repeater';
 
 /**
- * Given an AsyncIterable and a callback function, return an AsyncIterator
+ * Given an AsyncIterable and a callback function, return an AsyncGenerator
  * which produces values mapped via calling the callback function.
  */
-export function mapAsyncIterator<T, U>(
-  iterable: AsyncGenerator<T> | AsyncIterable<T>,
+export function mapAsyncIterable<T, U>(
+  iterable: AsyncIterable<T>,
   fn: (value: T) => PromiseOrValue<U>,
 ): AsyncGenerator<U> {
   return new Repeater(async (push, stop) => {


### PR DESCRIPTION
Also simplify function signature to just take AsyncIterables as named.