### PR TITLE
revert initial repeater implementation

### DIFF
--- a/src/execution/__tests__/stream-test.ts
+++ b/src/execution/__tests__/stream-test.ts
@@ -5,7 +5,6 @@ import type { DocumentNode } from 'graphql';
 import {
   GraphQLID,
   GraphQLList,
-  GraphQLNonNull,
   GraphQLObjectType,
   GraphQLSchema,
   GraphQLString,
@@ -20,7 +19,7 @@ import { expectJSON } from '../../__testUtils__/expectJSON';
 
 const friendType = new GraphQLObjectType({
   fields: {
-    id: { type: new GraphQLNonNull(GraphQLID) },
+    id: { type: GraphQLID },
     name: { type: GraphQLString },
     asyncName: {
       type: GraphQLString,
@@ -78,14 +77,6 @@ const query = new GraphQLObjectType({
       async *resolve() {
         yield await Promise.resolve(friends[0].name);
         yield await Promise.resolve({});
-      },
-    },
-    asyncIterableListNestedError: {
-      type: new GraphQLList(friendType),
-      async *resolve() {
-        yield await Promise.resolve(friends[0]);
-        yield await Promise.resolve({ id: Promise.reject(new Error('bad')) });
-        yield await Promise.resolve(friends[2]);
       },
     },
     asyncIterableListDelayed: {
@@ -679,56 +670,6 @@ describe('Execute: stream directive', () => {
           asyncName: 'Leia',
         },
         path: ['asyncIterableList', 2],
-        hasNext: false,
-      },
-    ]);
-  });
-
-  it('Handles rejected promises returned by completeValue after initialCount is reached', async () => {
-    const document = parse(`
-      query { 
-        asyncIterableListNestedError @stream(initialCount: 1) {
-          id
-          name
-        }
-      }
-    `);
-    const result = await complete(document);
-    expectJSON(result).toDeepEqual([
-      {
-        data: {
-          asyncIterableListNestedError: [
-            {
-              id: '1',
-              name: 'Luke',
-            },
-          ],
-        },
-        hasNext: true,
-      },
-      {
-        data: {
-          id: '3',
-          name: 'Leia',
-        },
-        path: ['asyncIterableListNestedError', 2],
-        hasNext: true,
-      },
-      {
-        errors: [
-          {
-            message: 'bad',
-            locations: [
-              {
-                line: 4,
-                column: 11,
-              },
-            ],
-            path: ['asyncIterableListNestedError', 1, 'id'],
-          },
-        ],
-        data: null,
-        path: ['asyncIterableListNestedError', 1],
         hasNext: false,
       },
     ]);

--- a/src/execution/__tests__/stream-test.ts
+++ b/src/execution/__tests__/stream-test.ts
@@ -670,6 +670,9 @@ describe('Execute: stream directive', () => {
           asyncName: 'Leia',
         },
         path: ['asyncIterableList', 2],
+        hasNext: true,
+      },
+      {
         hasNext: false,
       },
     ]);
@@ -843,11 +846,27 @@ describe('Execute: stream directive', () => {
 
     iterator.return?.();
 
-    // all calls to return and next settle in call order
+    // this result had started processing before return was called
     const result2 = await iterator.next();
     expect(result2).to.deep.equal({
-      done: true,
-      value: undefined,
+      done: false,
+      value: {
+        data: {
+          id: '2',
+          name: 'Han',
+        },
+        hasNext: true,
+        path: ['asyncIterableListDelayed', 1],
+      },
+    });
+
+    // third result is not returned because async iterator has returned
+    const result3 = await iterator.next();
+    expect(result3).to.deep.equal({
+      done: false,
+      value: {
+        hasNext: false,
+      },
     });
   });
   it('Can return async iterable when underlying iterable does not have a return method', async () => {
@@ -883,11 +902,27 @@ describe('Execute: stream directive', () => {
 
     iterator.return?.();
 
-    // all calls to return and next settle in call order
+    // this result had started processing before return was called
     const result2 = await iterator.next();
     expect(result2).to.deep.equal({
-      done: true,
-      value: undefined,
+      done: false,
+      value: {
+        data: {
+          id: '2',
+          name: 'Han',
+        },
+        hasNext: true,
+        path: ['asyncIterableListNoReturn', 1],
+      },
+    });
+
+    // third result is not returned because async iterator has returned
+    const result3 = await iterator.next();
+    expect(result3).to.deep.equal({
+      done: false,
+      value: {
+        hasNext: false,
+      },
     });
   });
   it('Returns underlying async iterables when dispatcher is thrown', async () => {
@@ -923,11 +958,27 @@ describe('Execute: stream directive', () => {
 
     iterator.throw?.(new Error('bad'));
 
-    // all calls to throw and next settle in call order
+    // this result had started processing before return was called
     const result2 = await iterator.next();
     expect(result2).to.deep.equal({
-      done: true,
-      value: undefined,
+      done: false,
+      value: {
+        data: {
+          id: '2',
+          name: 'Han',
+        },
+        hasNext: true,
+        path: ['asyncIterableListDelayed', 1],
+      },
+    });
+
+    // third result is not returned because async iterator has returned
+    const result3 = await iterator.next();
+    expect(result3).to.deep.equal({
+      done: false,
+      value: {
+        hasNext: false,
+      },
     });
   });
 });

--- a/src/execution/__tests__/stream-test.ts
+++ b/src/execution/__tests__/stream-test.ts
@@ -776,18 +776,18 @@ describe('Execute: stream directive', () => {
       },
       {
         data: {
-          name: 'Han',
-        },
-        path: ['asyncIterableList', 1],
-        label: 'DeferName',
-        hasNext: true,
-      },
-      {
-        data: {
           id: '3',
         },
         path: ['asyncIterableList', 2],
         label: 'stream-label',
+        hasNext: true,
+      },
+      {
+        data: {
+          name: 'Han',
+        },
+        path: ['asyncIterableList', 1],
+        label: 'DeferName',
         hasNext: true,
       },
       {
@@ -842,18 +842,18 @@ describe('Execute: stream directive', () => {
       },
       {
         data: {
-          name: 'Han',
-        },
-        path: ['asyncIterableListDelayedClose', 1],
-        label: 'DeferName',
-        hasNext: true,
-      },
-      {
-        data: {
           id: '3',
         },
         path: ['asyncIterableListDelayedClose', 2],
         label: 'stream-label',
+        hasNext: true,
+      },
+      {
+        data: {
+          name: 'Han',
+        },
+        path: ['asyncIterableListDelayedClose', 1],
+        label: 'DeferName',
         hasNext: true,
       },
       {

--- a/src/execution/executor.ts
+++ b/src/execution/executor.ts
@@ -1132,70 +1132,66 @@ export class Executor {
   ): Promise<ReadonlyArray<unknown>> {
     const stream = this.getStreamValues(exeContext, fieldNodes);
 
-    const completedResults: Array<unknown> = [];
+    // This is specified as a simple map, however we're optimizing the path
+    // where the list contains no Promises by avoiding creating another Promise.
     const promises: Array<Promise<void>> = [];
-    return new Promise<void>((resolve) => {
-      const next = (index: number) => {
-        if (
-          stream &&
-          typeof stream.initialCount === 'number' &&
-          index >= stream.initialCount
-        ) {
-          this.addAsyncIteratorValue(
-            index,
-            iterator,
-            exeContext,
-            fieldNodes,
-            info,
-            itemType,
-            path,
-            stream.label,
-          );
-          resolve();
-          return;
-        }
-
-        const itemPath = addPath(path, index, undefined);
-        iterator.next().then(
-          ({ value, done }) => {
-            if (done) {
-              resolve();
-              return;
-            }
-
-            this.completeListItemValue(
-              completedResults,
-              index,
-              promises,
-              value,
-              exeContext,
-              itemType,
-              fieldNodes,
-              info,
-              itemPath,
-              errors,
-            );
-
-            next(index + 1);
-          },
-          (rawError) => {
-            completedResults.push(null);
-            const error = locatedError(
-              rawError,
-              fieldNodes,
-              pathToArray(itemPath),
-            );
-            this.handleFieldError(error, itemType, errors);
-            resolve();
-          },
+    const completedResults: Array<unknown> = [];
+    let index = 0;
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      if (
+        stream &&
+        typeof stream.initialCount === 'number' &&
+        index >= stream.initialCount
+      ) {
+        this.addAsyncIteratorValue(
+          index,
+          iterator,
+          exeContext,
+          fieldNodes,
+          info,
+          itemType,
+          path,
+          stream.label,
         );
-      };
-      next(0);
-    }).then(() =>
-      promises.length
-        ? resolveAfterAll(completedResults, promises)
-        : completedResults,
-    );
+        break;
+      }
+
+      const itemPath = addPath(path, index, undefined);
+
+      let iteration: IteratorResult<unknown>;
+      try {
+        // eslint-disable-next-line no-await-in-loop
+        iteration = await iterator.next();
+      } catch (rawError) {
+        const error = locatedError(rawError, fieldNodes, pathToArray(itemPath));
+        completedResults.push(this.handleFieldError(error, itemType, errors));
+        break;
+      }
+
+      if (iteration.done) {
+        break;
+      }
+
+      this.completeListItemValue(
+        completedResults,
+        index,
+        promises,
+        iteration.value,
+        exeContext,
+        itemType,
+        fieldNodes,
+        info,
+        itemPath,
+        errors,
+      );
+
+      index++;
+    }
+
+    return promises.length
+      ? resolveAfterAll(completedResults, promises)
+      : completedResults;
   }
 
   completeListItemValue(

--- a/src/execution/executor.ts
+++ b/src/execution/executor.ts
@@ -37,7 +37,6 @@ import type { Path } from '../jsutils/Path';
 import type { ObjMap } from '../jsutils/ObjMap';
 import type { PromiseOrValue } from '../jsutils/PromiseOrValue';
 import type { Maybe } from '../jsutils/Maybe';
-import type { Push, Stop } from '../jsutils/repeater';
 import { inspect } from '../jsutils/inspect';
 import { memoize3 } from '../jsutils/memoize3';
 import { invariant } from '../jsutils/invariant';
@@ -49,7 +48,6 @@ import { addPath, pathToArray } from '../jsutils/Path';
 import { isAsyncIterable } from '../jsutils/isAsyncIterable';
 import { isIterableObject } from '../jsutils/isIterableObject';
 import { resolveAfterAll } from '../jsutils/resolveAfterAll';
-import { Repeater } from '../jsutils/repeater';
 
 import {
   getVariableValues,
@@ -103,39 +101,11 @@ interface ExecutionContext {
   disableIncremental: boolean;
   resolveField: FieldResolver;
   errors: Array<GraphQLError>;
-  patchInstructionSets: Array<PatchInstructionSet>;
-  iteratorInstructions: Array<IteratorInstruction>;
-  asyncIteratorInstructions: Array<AsyncIteratorInstruction>;
-  pendingPushes: number;
-  closed: boolean;
-  unfinishedIterators: Set<AsyncIterator<unknown>>;
-}
-
-interface PatchInstructionSet {
-  patches: Array<PatchFields>;
-  parentType: GraphQLObjectType;
-  source: unknown;
-  path: Path | undefined;
-}
-
-interface IteratorInstruction {
-  iterator: Iterator<unknown>;
-  itemType: GraphQLOutputType;
-  fieldNodes: ReadonlyArray<FieldNode>;
-  info: GraphQLResolveInfo;
-  initialIndex: number;
-  path: Path;
-  label?: string;
-}
-
-interface AsyncIteratorInstruction {
-  asyncIterator: AsyncIterator<unknown>;
-  itemType: GraphQLOutputType;
-  fieldNodes: ReadonlyArray<FieldNode>;
-  info: GraphQLResolveInfo;
-  initialIndex: number;
-  path: Path;
-  label?: string;
+  subsequentPayloads: Array<Promise<IteratorResult<DispatcherResult, void>>>;
+  initialResult?: ExecutionResult;
+  iterators: Array<AsyncIterator<unknown>>;
+  isDone: boolean;
+  hasReturnedInitialResult: boolean;
 }
 
 export interface ExecutionArgs {
@@ -190,6 +160,17 @@ export interface ExecutionPatchResult<
   label?: string;
   hasNext: boolean;
   extensions?: TExtensions;
+}
+
+/**
+ * Same as ExecutionPatchResult, but without hasNext
+ */
+interface DispatcherResult {
+  errors?: ReadonlyArray<GraphQLError>;
+  data?: ObjMap<unknown> | unknown | null;
+  path: ReadonlyArray<string | number>;
+  label?: string;
+  extensions?: ObjMap<unknown>;
 }
 
 export type AsyncExecutionResult = ExecutionResult | ExecutionPatchResult;
@@ -392,262 +373,19 @@ export class Executor {
   buildResponse(
     exeContext: ExecutionContext,
     data: ObjMap<unknown> | null,
-  ): ExecutionResult | AsyncGenerator<AsyncExecutionResult, void, void> {
+  ): PromiseOrValue<
+    ExecutionResult | AsyncGenerator<AsyncExecutionResult, void, void>
+  > {
     const initialResult =
       exeContext.errors.length === 0
         ? { data }
         : { errors: exeContext.errors, data };
 
-    if (this.hasPendingInstructions(exeContext)) {
-      return new Repeater((push, stop) => {
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        push({
-          ...initialResult,
-          hasNext: true,
-        });
-        this.processInstructions(exeContext, push, stop);
-      });
+    if (this.hasSubsequentPayloads(exeContext)) {
+      return this.get(exeContext, initialResult);
     }
 
     return initialResult;
-  }
-
-  processInstructions(
-    exeContext: ExecutionContext,
-    push: Push<AsyncExecutionResult>,
-    stop: Stop,
-  ): void {
-    while (this.hasPendingInstructions(exeContext)) {
-      this.pushPatchInstructionSets(exeContext, push, stop);
-      this.pushIteratorInstructions(exeContext, push, stop);
-      this.pushAsyncIteratorInstructions(exeContext, push, stop);
-    }
-  }
-
-  pushPatchInstructionSets(
-    exeContext: ExecutionContext,
-    push: Push<AsyncExecutionResult>,
-    stop: Stop,
-  ): void {
-    const { patchInstructionSets } = exeContext;
-    exeContext.patchInstructionSets = [];
-    for (const patchInstructionSet of patchInstructionSets) {
-      const { patches, parentType, source, path } = patchInstructionSet;
-      for (const { fields, label } of patches) {
-        const errors: Array<GraphQLError> = [];
-        exeContext.pendingPushes++;
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        Promise.resolve(
-          this.executeFields(
-            exeContext,
-            parentType,
-            source,
-            path,
-            fields,
-            errors,
-          ),
-        ).then((deferredData) => {
-          exeContext.pendingPushes--;
-          this.pushResult(
-            exeContext,
-            push,
-            stop,
-            deferredData,
-            label,
-            path,
-            errors,
-          );
-        });
-      }
-    }
-  }
-
-  pushIteratorInstructions(
-    exeContext: ExecutionContext,
-    push: Push<AsyncExecutionResult>,
-    stop: Stop,
-  ): void {
-    const { iteratorInstructions } = exeContext;
-    exeContext.iteratorInstructions = [];
-    for (const iteratorInstruction of iteratorInstructions) {
-      const {
-        iterator,
-        itemType,
-        fieldNodes,
-        info,
-        initialIndex,
-        path,
-        label,
-      } = iteratorInstruction;
-      let index = initialIndex;
-      let iteration = iterator.next();
-      while (!iteration.done) {
-        const itemPath = addPath(path, index, undefined);
-
-        const errors: Array<GraphQLError> = [];
-        exeContext.pendingPushes++;
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        Promise.resolve(iteration.value)
-          .then((resolved) =>
-            this.completeValue(
-              exeContext,
-              itemType,
-              fieldNodes,
-              info,
-              itemPath,
-              resolved,
-              errors,
-            ),
-          )
-          // Note: we don't rely on a `catch` method, but we do expect "thenable"
-          // to take a second callback for the error case.
-          .then(undefined, (rawError) => {
-            const error = locatedError(
-              rawError,
-              fieldNodes,
-              pathToArray(itemPath),
-            );
-            return this.handleFieldError(error, itemType, errors);
-          })
-          .then((completed) => {
-            exeContext.pendingPushes--;
-            this.pushResult(
-              exeContext,
-              push,
-              stop,
-              completed,
-              label,
-              itemPath,
-              errors,
-            );
-          });
-
-        index++;
-        iteration = iterator.next();
-      }
-    }
-  }
-
-  pushAsyncIteratorInstructions(
-    exeContext: ExecutionContext,
-    push: Push<AsyncExecutionResult>,
-    stop: Stop,
-  ): void {
-    const { asyncIteratorInstructions, unfinishedIterators } = exeContext;
-    exeContext.asyncIteratorInstructions = [];
-    for (const asyncIteratorInstruction of asyncIteratorInstructions) {
-      const {
-        asyncIterator,
-        itemType,
-        fieldNodes,
-        info,
-        initialIndex,
-        path,
-        label,
-      } = asyncIteratorInstruction;
-      unfinishedIterators.add(asyncIterator);
-      const next = (index: number) => {
-        const itemPath = addPath(path, index, undefined);
-        const errors: Array<GraphQLError> = [];
-        asyncIterator.next().then(
-          ({ value, done }) => {
-            if (done) {
-              unfinishedIterators.delete(asyncIterator);
-              if (!this.hasNext(exeContext)) {
-                // eslint-disable-next-line @typescript-eslint/no-floating-promises
-                push({
-                  hasNext: false,
-                });
-                stop();
-              }
-              return;
-            }
-
-            exeContext.pendingPushes++;
-            // eslint-disable-next-line node/callback-return
-            next(index + 1);
-
-            try {
-              const completedItem = this.completeValue(
-                exeContext,
-                itemType,
-                fieldNodes,
-                info,
-                itemPath,
-                value,
-                errors,
-              );
-
-              if (isPromise(completedItem)) {
-                // eslint-disable-next-line @typescript-eslint/no-floating-promises
-                completedItem.then((resolved) => {
-                  exeContext.pendingPushes--;
-                  this.pushResult(
-                    exeContext,
-                    push,
-                    stop,
-                    resolved,
-                    label,
-                    itemPath,
-                    errors,
-                  );
-                });
-                return;
-              }
-
-              exeContext.pendingPushes--;
-              this.pushResult(
-                exeContext,
-                push,
-                stop,
-                completedItem,
-                label,
-                itemPath,
-                errors,
-              );
-            } catch (rawError) {
-              const error = locatedError(
-                rawError,
-                fieldNodes,
-                pathToArray(itemPath),
-              );
-              this.handleFieldError(error, itemType, errors);
-              exeContext.pendingPushes--;
-              this.pushResult(
-                exeContext,
-                push,
-                stop,
-                null,
-                label,
-                itemPath,
-                errors,
-              );
-            }
-          },
-          (rawError) => {
-            unfinishedIterators.delete(asyncIterator);
-            const error = locatedError(
-              rawError,
-              fieldNodes,
-              pathToArray(itemPath),
-            );
-            this.handleFieldError(error, itemType, errors);
-            exeContext.pendingPushes--;
-            this.pushResult(
-              exeContext,
-              push,
-              stop,
-              null,
-              label,
-              itemPath,
-              errors,
-            );
-          },
-        );
-      };
-      // eslint-disable-next-line node/callback-return
-      next(initialIndex);
-    }
   }
 
   /**
@@ -797,12 +535,10 @@ export class Executor {
             )
           : this.buildFieldResolver('resolve', defaultResolveFieldValueFn),
       errors: [],
-      patchInstructionSets: [],
-      iteratorInstructions: [],
-      asyncIteratorInstructions: [],
-      pendingPushes: 0,
-      closed: false,
-      unfinishedIterators: new Set(),
+      subsequentPayloads: [],
+      iterators: [],
+      isDone: false,
+      hasReturnedInitialResult: false,
     };
   }
 
@@ -823,12 +559,6 @@ export class Executor {
         exeContext.fieldResolver,
       ),
       errors: [],
-      patchInstructionSets: [],
-      iteratorInstructions: [],
-      asyncIteratorInstructions: [],
-      pendingPushes: 0,
-      closed: false,
-      unfinishedIterators: new Set(),
     };
   }
 
@@ -870,14 +600,7 @@ export class Executor {
       errors,
     );
 
-    if (patches.length) {
-      exeContext.patchInstructionSets.push({
-        patches,
-        parentType: rootType,
-        source: rootValue,
-        path,
-      });
-    }
+    this.addPatches(exeContext, patches, rootType, rootValue, path);
 
     return result;
   }
@@ -1354,15 +1077,16 @@ export class Executor {
         typeof stream.initialCount === 'number' &&
         index >= stream.initialCount
       ) {
-        exeContext.iteratorInstructions.push({
+        this.addIteratorValue(
+          index,
           iterator,
-          itemType,
+          exeContext,
           fieldNodes,
           info,
-          initialIndex: index,
+          itemType,
           path,
-          label: stream.label,
-        });
+          stream.label,
+        );
         break;
       }
 
@@ -1417,15 +1141,16 @@ export class Executor {
           typeof stream.initialCount === 'number' &&
           index >= stream.initialCount
         ) {
-          exeContext.asyncIteratorInstructions.push({
-            asyncIterator: iterator,
-            itemType,
+          this.addAsyncIteratorValue(
+            index,
+            iterator,
+            exeContext,
             fieldNodes,
             info,
-            initialIndex: index,
+            itemType,
             path,
-            label: stream.label,
-          });
+            stream.label,
+          );
           resolve();
           return;
         }
@@ -1754,14 +1479,7 @@ export class Executor {
       errors,
     );
 
-    if (subPatches.length) {
-      exeContext.patchInstructionSets.push({
-        patches: subPatches,
-        parentType: returnType,
-        source: result,
-        path,
-      });
-    }
+    this.addPatches(exeContext, subPatches, returnType, result, path);
 
     return subFields;
   }
@@ -1945,86 +1663,324 @@ export class Executor {
     return this.executeQueryAlgorithm(exeContext);
   }
 
-  hasPendingInstructions(exeContext: ExecutionContext): boolean {
-    const {
-      patchInstructionSets,
-      iteratorInstructions,
-      asyncIteratorInstructions,
-    } = exeContext;
-    return (
-      patchInstructionSets.length !== 0 ||
-      iteratorInstructions.length !== 0 ||
-      asyncIteratorInstructions.length !== 0
-    );
+  hasSubsequentPayloads(exeContext: ExecutionContext) {
+    return exeContext.subsequentPayloads.length !== 0;
   }
 
-  hasPendingValues(exeContext: ExecutionContext): boolean {
-    const {
-      patchInstructionSets,
-      iteratorInstructions,
-      asyncIteratorInstructions,
-      unfinishedIterators,
-    } = exeContext;
-    return (
-      patchInstructionSets.length !== 0 ||
-      iteratorInstructions.length !== 0 ||
-      asyncIteratorInstructions.length !== 0 ||
-      unfinishedIterators.size !== 0
-    );
-  }
-
-  hasNext(exeContext: ExecutionContext): boolean {
-    return (
-      this.hasPendingValues(exeContext) ||
-      exeContext.pendingPushes > 0 ||
-      exeContext.unfinishedIterators.size > 0
-    );
-  }
-
-  pushResult(
+  addPatches(
     exeContext: ExecutionContext,
-    push: Push<ExecutionResult | AsyncExecutionResult>,
-    stop: Stop,
+    patches: Array<PatchFields>,
+    parentType: GraphQLObjectType,
+    source: unknown,
+    path: Path | undefined,
+  ): void {
+    for (const patch of patches) {
+      const { label, fields: patchFields } = patch;
+      const errors: Array<GraphQLError> = [];
+      exeContext.subsequentPayloads.push(
+        Promise.resolve(
+          this.executeFields(
+            exeContext,
+            parentType,
+            source,
+            path,
+            patchFields,
+            errors,
+          ),
+        ).then((data) => ({
+          value: this.createPatchResult(data, label, path, errors),
+          done: false,
+        })),
+      );
+    }
+  }
+
+  addIteratorValue(
+    initialIndex: number,
+    iterator: Iterator<unknown>,
+    exeContext: ExecutionContext,
+    fieldNodes: ReadonlyArray<FieldNode>,
+    info: GraphQLResolveInfo,
+    itemType: GraphQLOutputType,
+    path: Path,
+    label?: string,
+  ): void {
+    let index = initialIndex;
+    let iteration = iterator.next();
+    while (!iteration.done) {
+      const itemPath = addPath(path, index, undefined);
+
+      const errors: Array<GraphQLError> = [];
+      exeContext.subsequentPayloads.push(
+        Promise.resolve(iteration.value)
+          .then((resolved) =>
+            this.completeValue(
+              exeContext,
+              itemType,
+              fieldNodes,
+              info,
+              itemPath,
+              resolved,
+              errors,
+            ),
+          )
+          // Note: we don't rely on a `catch` method, but we do expect "thenable"
+          // to take a second callback for the error case.
+          .then(undefined, (rawError) => {
+            const error = locatedError(
+              rawError,
+              fieldNodes,
+              pathToArray(itemPath),
+            );
+            return this.handleFieldError(error, itemType, errors);
+          })
+          .then((data) => ({
+            value: this.createPatchResult(data, label, itemPath, errors),
+            done: false,
+          })),
+      );
+
+      index++;
+      iteration = iterator.next();
+    }
+  }
+
+  addAsyncIteratorValue(
+    initialIndex: number,
+    iterator: AsyncIterator<unknown>,
+    exeContext: ExecutionContext,
+    fieldNodes: ReadonlyArray<FieldNode>,
+    info: GraphQLResolveInfo,
+    itemType: GraphQLOutputType,
+    path: Path,
+    label?: string,
+  ): void {
+    const { subsequentPayloads, iterators } = exeContext;
+    iterators.push(iterator);
+    const next = (index: number) => {
+      const itemPath = addPath(path, index, undefined);
+      const errors: Array<GraphQLError> = [];
+      subsequentPayloads.push(
+        iterator.next().then(
+          ({ value: data, done }) => {
+            if (done) {
+              iterators.splice(iterators.indexOf(iterator), 1);
+              return { value: undefined, done: true };
+            }
+
+            // eslint-disable-next-line node/callback-return
+            next(index + 1);
+
+            try {
+              const completedItem = this.completeValue(
+                exeContext,
+                itemType,
+                fieldNodes,
+                info,
+                itemPath,
+                data,
+                errors,
+              );
+
+              if (isPromise(completedItem)) {
+                return completedItem.then((resolveItem) => ({
+                  value: this.createPatchResult(
+                    resolveItem,
+                    label,
+                    itemPath,
+                    errors,
+                  ),
+                  done: false,
+                }));
+              }
+
+              return {
+                value: this.createPatchResult(
+                  completedItem,
+                  label,
+                  itemPath,
+                  errors,
+                ),
+                done: false,
+              };
+            } catch (rawError) {
+              const error = locatedError(
+                rawError,
+                fieldNodes,
+                pathToArray(itemPath),
+              );
+              this.handleFieldError(error, itemType, errors);
+              return {
+                value: this.createPatchResult(null, label, itemPath, errors),
+                done: false,
+              };
+            }
+          },
+          (rawError) => {
+            const error = locatedError(
+              rawError,
+              fieldNodes,
+              pathToArray(itemPath),
+            );
+            this.handleFieldError(error, itemType, errors);
+            return {
+              value: this.createPatchResult(null, label, itemPath, errors),
+              done: false,
+            };
+          },
+        ),
+      );
+    };
+    next(initialIndex);
+  }
+
+  _race(
+    exeContext: ExecutionContext,
+  ): Promise<IteratorResult<ExecutionPatchResult, void>> {
+    if (exeContext.isDone) {
+      return Promise.resolve({
+        value: {
+          hasNext: false,
+        },
+        done: false,
+      });
+    }
+    return new Promise((resolve) => {
+      let resolved = false;
+      exeContext.subsequentPayloads.forEach((promise) => {
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        promise.then((payload) => {
+          if (resolved) {
+            return;
+          }
+
+          resolved = true;
+
+          if (exeContext.subsequentPayloads.length === 0) {
+            // a different call to next has exhausted all payloads
+            resolve({ value: undefined, done: true });
+            return;
+          }
+
+          const index = exeContext.subsequentPayloads.indexOf(promise);
+
+          if (index === -1) {
+            // a different call to next has consumed this payload
+            resolve(this._race(exeContext));
+            return;
+          }
+
+          exeContext.subsequentPayloads.splice(index, 1);
+
+          const { value, done } = payload;
+
+          if (done && exeContext.subsequentPayloads.length === 0) {
+            // async iterable resolver just finished and no more pending payloads
+            resolve({
+              value: {
+                hasNext: false,
+              },
+              done: false,
+            });
+            return;
+          } else if (done) {
+            // async iterable resolver just finished but there are pending payloads
+            // return the next one
+            resolve(this._race(exeContext));
+            return;
+          }
+
+          const returnValue: ExecutionPatchResult = {
+            ...value,
+            hasNext: exeContext.subsequentPayloads.length > 0,
+          };
+          resolve({
+            value: returnValue,
+            done: false,
+          });
+        });
+      });
+    });
+  }
+
+  _next(
+    exeContext: ExecutionContext,
+  ): Promise<IteratorResult<AsyncExecutionResult, void>> {
+    if (!exeContext.hasReturnedInitialResult) {
+      exeContext.hasReturnedInitialResult = true;
+      return Promise.resolve({
+        value: {
+          ...exeContext.initialResult,
+          hasNext: true,
+        },
+        done: false,
+      });
+    } else if (exeContext.subsequentPayloads.length === 0) {
+      return Promise.resolve({ value: undefined, done: true });
+    }
+    return this._race(exeContext);
+  }
+
+  async _return(
+    exeContext: ExecutionContext,
+  ): Promise<IteratorResult<AsyncExecutionResult, void>> {
+    await Promise.all(
+      exeContext.iterators.map((iterator) => iterator.return?.()),
+    );
+    // no updates will be missed, transitions only happen to `done` state
+    // eslint-disable-next-line require-atomic-updates
+    exeContext.isDone = true;
+    return { value: undefined, done: true };
+  }
+
+  async _throw(
+    exeContext: ExecutionContext,
+    error?: unknown,
+  ): Promise<IteratorResult<AsyncExecutionResult, void>> {
+    await Promise.all(
+      exeContext.iterators.map((iterator) => iterator.return?.()),
+    );
+    // no updates will be missed, transitions only happen to `done` state
+    // eslint-disable-next-line require-atomic-updates
+    exeContext.isDone = true;
+    return Promise.reject(error);
+  }
+
+  get(
+    exeContext: ExecutionContext,
+    initialResult: ExecutionResult,
+  ): AsyncGenerator<AsyncExecutionResult> {
+    exeContext.initialResult = initialResult;
+    return {
+      [Symbol.asyncIterator]() {
+        return this;
+      },
+      next: () => this._next(exeContext),
+      return: () => this._return(exeContext),
+      throw: (error?: unknown) => this._throw(exeContext, error),
+    };
+  }
+
+  createPatchResult(
     data: ObjMap<unknown> | unknown | null,
     label?: string,
     path?: Path,
     errors?: ReadonlyArray<GraphQLError>,
-  ): void {
-    const hasNext = this.hasNext(exeContext);
-
-    if (!hasNext) {
-      exeContext.closed = true;
-    }
-
-    const result: ExecutionPatchResult = {
+  ): DispatcherResult {
+    const value: DispatcherResult = {
       data,
       path: path ? pathToArray(path) : [],
-      hasNext: this.hasNext(exeContext),
     };
 
     if (label != null) {
-      result.label = label;
+      value.label = label;
     }
 
     if (errors && errors.length > 0) {
-      result.errors = errors;
+      value.errors = errors;
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    push(result).then(() => {
-      if (!this.hasNext(exeContext)) {
-        if (!exeContext.closed) {
-          // eslint-disable-next-line @typescript-eslint/no-floating-promises
-          push({
-            hasNext: false,
-          });
-        }
-        stop();
-        return;
-      }
-
-      this.processInstructions(exeContext, push, stop);
-    });
+    return value;
   }
 }
 

--- a/src/execution/executor.ts
+++ b/src/execution/executor.ts
@@ -417,22 +417,34 @@ export class Executor {
     push: Push<AsyncExecutionResult>,
     stop: Stop,
   ): void {
-    const {
-      patchInstructionSets,
-      iteratorInstructions,
-      asyncIteratorInstructions,
-    } = exeContext;
-    exeContext.patchInstructionSets = [];
-    exeContext.iteratorInstructions = [];
-    exeContext.asyncIteratorInstructions = [];
-    this.pushPatchInstructionSets(exeContext, patchInstructionSets, push, stop);
-    this.pushIteratorInstructions(exeContext, iteratorInstructions, push, stop);
-    this.pushAsyncIteratorInstructions(
-      exeContext,
-      asyncIteratorInstructions,
-      push,
-      stop,
-    );
+    while (this.hasPendingInstructions(exeContext)) {
+      const {
+        patchInstructionSets,
+        iteratorInstructions,
+        asyncIteratorInstructions,
+      } = exeContext;
+      exeContext.patchInstructionSets = [];
+      exeContext.iteratorInstructions = [];
+      exeContext.asyncIteratorInstructions = [];
+      this.pushPatchInstructionSets(
+        exeContext,
+        patchInstructionSets,
+        push,
+        stop,
+      );
+      this.pushIteratorInstructions(
+        exeContext,
+        iteratorInstructions,
+        push,
+        stop,
+      );
+      this.pushAsyncIteratorInstructions(
+        exeContext,
+        asyncIteratorInstructions,
+        push,
+        stop,
+      );
+    }
   }
 
   pushPatchInstructionSets(

--- a/src/execution/executor.ts
+++ b/src/execution/executor.ts
@@ -457,7 +457,6 @@ export class Executor {
             errors,
           ),
         ).then((deferredData) => {
-          this.processInstructions(exeContext, push, stop);
           this.pushPatchResult(
             exeContext,
             push,
@@ -519,7 +518,6 @@ export class Executor {
             return this.handleFieldError(error, itemType, errors);
           })
           .then((completed) => {
-            this.processInstructions(exeContext, push, stop);
             this.pushPatchResult(
               exeContext,
               push,
@@ -588,7 +586,6 @@ export class Executor {
                 errors,
               );
             } catch (rawError) {
-              this.processInstructions(exeContext, push, stop);
               const error = locatedError(
                 rawError,
                 fieldNodes,
@@ -610,7 +607,6 @@ export class Executor {
             if (isPromise(completedItem)) {
               completedItem.then(
                 (resolved) => {
-                  this.processInstructions(exeContext, push, stop);
                   this.pushPatchResult(
                     exeContext,
                     push,
@@ -622,7 +618,6 @@ export class Executor {
                   );
                 },
                 (rawError) => {
-                  this.processInstructions(exeContext, push, stop);
                   const error = locatedError(
                     rawError,
                     fieldNodes,
@@ -643,7 +638,6 @@ export class Executor {
               return;
             }
 
-            this.processInstructions(exeContext, push, stop);
             this.pushPatchResult(
               exeContext,
               push,
@@ -655,7 +649,6 @@ export class Executor {
             );
           },
           (rawError) => {
-            this.processInstructions(exeContext, push, stop);
             unfinishedIterators.delete(asyncIterator);
             const error = locatedError(
               rawError,
@@ -2052,7 +2045,10 @@ export class Executor {
           });
         }
         stop();
+        return;
       }
+
+      this.processInstructions(exeContext, push, stop);
     });
   }
 }

--- a/src/execution/executor.ts
+++ b/src/execution/executor.ts
@@ -418,41 +418,19 @@ export class Executor {
     stop: Stop,
   ): void {
     while (this.hasPendingInstructions(exeContext)) {
-      const {
-        patchInstructionSets,
-        iteratorInstructions,
-        asyncIteratorInstructions,
-      } = exeContext;
-      exeContext.patchInstructionSets = [];
-      exeContext.iteratorInstructions = [];
-      exeContext.asyncIteratorInstructions = [];
-      this.pushPatchInstructionSets(
-        exeContext,
-        patchInstructionSets,
-        push,
-        stop,
-      );
-      this.pushIteratorInstructions(
-        exeContext,
-        iteratorInstructions,
-        push,
-        stop,
-      );
-      this.pushAsyncIteratorInstructions(
-        exeContext,
-        asyncIteratorInstructions,
-        push,
-        stop,
-      );
+      this.pushPatchInstructionSets(exeContext, push, stop);
+      this.pushIteratorInstructions(exeContext, push, stop);
+      this.pushAsyncIteratorInstructions(exeContext, push, stop);
     }
   }
 
   pushPatchInstructionSets(
     exeContext: ExecutionContext,
-    patchInstructionSets: Array<PatchInstructionSet>,
     push: Push<AsyncExecutionResult>,
     stop: Stop,
   ): void {
+    const { patchInstructionSets } = exeContext;
+    exeContext.patchInstructionSets = [];
     for (const patchInstructionSet of patchInstructionSets) {
       const { patches, parentType, source, path } = patchInstructionSet;
       for (const { fields, label } of patches) {
@@ -486,10 +464,11 @@ export class Executor {
 
   pushIteratorInstructions(
     exeContext: ExecutionContext,
-    iteratorInstructions: Array<IteratorInstruction>,
     push: Push<AsyncExecutionResult>,
     stop: Stop,
   ): void {
+    const { iteratorInstructions } = exeContext;
+    exeContext.iteratorInstructions = [];
     for (const iteratorInstruction of iteratorInstructions) {
       const {
         iterator,
@@ -551,11 +530,11 @@ export class Executor {
 
   pushAsyncIteratorInstructions(
     exeContext: ExecutionContext,
-    asyncIteratorInstructions: Array<AsyncIteratorInstruction>,
     push: Push<AsyncExecutionResult>,
     stop: Stop,
   ): void {
-    const { unfinishedIterators } = exeContext;
+    const { asyncIteratorInstructions, unfinishedIterators } = exeContext;
+    exeContext.asyncIteratorInstructions = [];
     for (const asyncIteratorInstruction of asyncIteratorInstructions) {
       const {
         asyncIterator,

--- a/src/execution/executor.ts
+++ b/src/execution/executor.ts
@@ -414,7 +414,7 @@ export class Executor {
 
   processInstructions(
     exeContext: ExecutionContext,
-    push: Push<ExecutionPatchResult>,
+    push: Push<AsyncExecutionResult>,
     stop: Stop,
   ): void {
     const {
@@ -438,7 +438,7 @@ export class Executor {
   pushPatchInstructionSets(
     exeContext: ExecutionContext,
     patchInstructionSets: Array<PatchInstructionSet>,
-    push: Push<ExecutionPatchResult>,
+    push: Push<AsyncExecutionResult>,
     stop: Stop,
   ): void {
     for (const patchInstructionSet of patchInstructionSets) {
@@ -474,7 +474,7 @@ export class Executor {
   pushIteratorInstructions(
     exeContext: ExecutionContext,
     iteratorInstructions: Array<IteratorInstruction>,
-    push: Push<ExecutionPatchResult>,
+    push: Push<AsyncExecutionResult>,
     stop: Stop,
   ): void {
     for (const iteratorInstruction of iteratorInstructions) {
@@ -538,7 +538,7 @@ export class Executor {
   pushAsyncIteratorInstructions(
     exeContext: ExecutionContext,
     asyncIteratorInstructions: Array<AsyncIteratorInstruction>,
-    push: Push<ExecutionPatchResult>,
+    push: Push<AsyncExecutionResult>,
     stop: Stop,
   ): void {
     const { unfinishedIterators } = exeContext;
@@ -2006,7 +2006,7 @@ export class Executor {
 
   pushPatchResult(
     exeContext: ExecutionContext,
-    push: Push<ExecutionPatchResult>,
+    push: Push<ExecutionResult | AsyncExecutionResult>,
     stop: Stop,
     data: ObjMap<unknown> | unknown | null,
     errors: ReadonlyArray<GraphQLError>,

--- a/src/execution/executor.ts
+++ b/src/execution/executor.ts
@@ -510,38 +510,26 @@ export class Executor {
           )
           // Note: we don't rely on a `catch` method, but we do expect "thenable"
           // to take a second callback for the error case.
-          .then(
-            (completed) => {
-              this.processInstructions(exeContext, push, stop);
-              this.pushPatchResult(
-                exeContext,
-                push,
-                stop,
-                completed,
-                errors,
-                itemPath,
-                label,
-              );
-            },
-            (rawError) => {
-              const error = locatedError(
-                rawError,
-                fieldNodes,
-                pathToArray(itemPath),
-              );
-              this.handleFieldError(error, itemType, errors);
-              this.pushPatchResult(
-                exeContext,
-                push,
-                stop,
-                null,
-                errors,
-                itemPath,
-                label,
-              );
-            },
-          )
-          .then();
+          .then(undefined, (rawError) => {
+            const error = locatedError(
+              rawError,
+              fieldNodes,
+              pathToArray(itemPath),
+            );
+            return this.handleFieldError(error, itemType, errors);
+          })
+          .then((completed) => {
+            this.processInstructions(exeContext, push, stop);
+            this.pushPatchResult(
+              exeContext,
+              push,
+              stop,
+              completed,
+              errors,
+              itemPath,
+              label,
+            );
+          });
 
         index++;
         iteration = iterator.next();
@@ -600,6 +588,7 @@ export class Executor {
                 errors,
               );
             } catch (rawError) {
+              this.processInstructions(exeContext, push, stop);
               const error = locatedError(
                 rawError,
                 fieldNodes,
@@ -633,6 +622,7 @@ export class Executor {
                   );
                 },
                 (rawError) => {
+                  this.processInstructions(exeContext, push, stop);
                   const error = locatedError(
                     rawError,
                     fieldNodes,
@@ -665,6 +655,7 @@ export class Executor {
             );
           },
           (rawError) => {
+            this.processInstructions(exeContext, push, stop);
             unfinishedIterators.delete(asyncIterator);
             const error = locatedError(
               rawError,

--- a/src/execution/executor.ts
+++ b/src/execution/executor.ts
@@ -469,14 +469,15 @@ export class Executor {
             errors,
           ),
         ).then((deferredData) => {
-          this.pushPatchResult(
+          exeContext.pendingPushes--;
+          this.pushResult(
             exeContext,
             push,
             stop,
             deferredData,
-            errors,
-            path,
             label,
+            path,
+            errors,
           );
         });
       }
@@ -530,14 +531,15 @@ export class Executor {
             return this.handleFieldError(error, itemType, errors);
           })
           .then((completed) => {
-            this.pushPatchResult(
+            exeContext.pendingPushes--;
+            this.pushResult(
               exeContext,
               push,
               stop,
               completed,
-              errors,
-              itemPath,
               label,
+              itemPath,
+              errors,
             );
           });
 
@@ -604,14 +606,15 @@ export class Executor {
                 pathToArray(itemPath),
               );
               this.handleFieldError(error, itemType, errors);
-              this.pushPatchResult(
+              exeContext.pendingPushes--;
+              this.pushResult(
                 exeContext,
                 push,
                 stop,
                 null,
-                errors,
-                itemPath,
                 label,
+                itemPath,
+                errors,
               );
               return;
             }
@@ -619,14 +622,15 @@ export class Executor {
             if (isPromise(completedItem)) {
               completedItem.then(
                 (resolved) => {
-                  this.pushPatchResult(
+                  exeContext.pendingPushes--;
+                  this.pushResult(
                     exeContext,
                     push,
                     stop,
                     resolved,
-                    errors,
-                    itemPath,
                     label,
+                    itemPath,
+                    errors,
                   );
                 },
                 (rawError) => {
@@ -636,28 +640,30 @@ export class Executor {
                     pathToArray(itemPath),
                   );
                   this.handleFieldError(error, itemType, errors);
-                  this.pushPatchResult(
+                  exeContext.pendingPushes--;
+                  this.pushResult(
                     exeContext,
                     push,
                     stop,
                     null,
-                    errors,
-                    itemPath,
                     label,
+                    itemPath,
+                    errors,
                   );
                 },
               );
               return;
             }
 
-            this.pushPatchResult(
+            exeContext.pendingPushes--;
+            this.pushResult(
               exeContext,
               push,
               stop,
               completedItem,
-              errors,
-              itemPath,
               label,
+              itemPath,
+              errors,
             );
           },
           (rawError) => {
@@ -668,14 +674,15 @@ export class Executor {
               pathToArray(itemPath),
             );
             this.handleFieldError(error, itemType, errors);
-            this.pushPatchResult(
+            exeContext.pendingPushes--;
+            this.pushResult(
               exeContext,
               push,
               stop,
               null,
-              errors,
-              itemPath,
               label,
+              itemPath,
+              errors,
             );
           },
         );
@@ -2016,17 +2023,15 @@ export class Executor {
     );
   }
 
-  pushPatchResult(
+  pushResult(
     exeContext: ExecutionContext,
     push: Push<ExecutionResult | AsyncExecutionResult>,
     stop: Stop,
     data: ObjMap<unknown> | unknown | null,
-    errors: ReadonlyArray<GraphQLError>,
-    path?: Path,
     label?: string,
+    path?: Path,
+    errors?: ReadonlyArray<GraphQLError>,
   ): void {
-    exeContext.pendingPushes--;
-
     const hasNext = this.hasNext(exeContext);
 
     if (!hasNext) {


### PR DESCRIPTION
Unfortunately, this implementation deferred payloads a bit too long, not beginning processing of the next payload until the prior payload resolved.