### PR TITLE
move guard to appropriate location

### DIFF
--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -1,6 +1,7 @@
 import type { PromiseOrValue } from '../jsutils/PromiseOrValue';
 import { isPromise } from '../jsutils/isPromise';
 import { isAsyncIterable } from '../jsutils/isAsyncIterable';
+import { devAssert } from '../jsutils/devAssert';
 
 import type {
   ExecutionArgs,
@@ -24,6 +25,12 @@ export function execute(
 ): PromiseOrValue<
   ExecutionResult | AsyncGenerator<AsyncExecutionResult, void, void>
 > {
+  // Temporary for v15 to v16 migration. Remove in v17
+  devAssert(
+    arguments.length < 2,
+    'graphql@16 dropped long-deprecated support for positional arguments, please pass an object instead.',
+  );
+
   const executor = new Executor();
   return executor.execute(args);
 }

--- a/src/execution/executor.ts
+++ b/src/execution/executor.ts
@@ -257,12 +257,6 @@ export class Executor {
   ): PromiseOrValue<
     ExecutionResult | AsyncGenerator<AsyncExecutionResult, void, void>
   > {
-    // Temporary for v15 to v16 migration. Remove in v17
-    devAssert(
-      arguments.length < 2,
-      'graphql@16 dropped long-deprecated support for positional arguments, please pass an object instead.',
-    );
-
     const exeContext = this.buildExecutionContext(args);
 
     // If a valid execution context cannot be created due to incorrect arguments,


### PR DESCRIPTION
guard only necessary for those using graphql-execute as drop-in replacement for graphql@15