### PR TITLE
merge latest defer-stream

### DIFF
--- a/src/execution/executor.ts
+++ b/src/execution/executor.ts
@@ -1072,54 +1072,54 @@ export class Executor {
     );
   }
 
-/**
- * Returns an object containing the `@stream` arguments if a field should be
- * streamed based on the experimental flag, stream directive present and
- * not disabled by the "if" argument.
- */
- getStreamValues(
-  exeContext: ExecutionContext,
-  fieldNodes: ReadonlyArray<FieldNode>,
-):
-  | undefined
-  | {
-      initialCount?: number;
-      label?: string;
-    } {
-  if (exeContext.disableIncremental) {
-    return;
+  /**
+   * Returns an object containing the `@stream` arguments if a field should be
+   * streamed based on the experimental flag, stream directive present and
+   * not disabled by the "if" argument.
+   */
+  getStreamValues(
+    exeContext: ExecutionContext,
+    fieldNodes: ReadonlyArray<FieldNode>,
+  ):
+    | undefined
+    | {
+        initialCount?: number;
+        label?: string;
+      } {
+    if (exeContext.disableIncremental) {
+      return;
+    }
+    // validation only allows equivalent streams on multiple fields, so it is
+    // safe to only check the first fieldNode for the stream directive
+    const stream = getDirectiveValues(
+      GraphQLStreamDirective,
+      fieldNodes[0],
+      exeContext.variableValues,
+    );
+
+    if (!stream) {
+      return;
+    }
+
+    if (stream.if === false) {
+      return;
+    }
+
+    invariant(
+      typeof stream.initialCount === 'number',
+      'initialCount must be a number',
+    );
+
+    invariant(
+      stream.initialCount >= 0,
+      'initialCount must be a positive integer',
+    );
+
+    return {
+      initialCount: stream.initialCount,
+      label: typeof stream.label === 'string' ? stream.label : undefined,
+    };
   }
-  // validation only allows equivalent streams on multiple fields, so it is
-  // safe to only check the first fieldNode for the stream directive
-  const stream = getDirectiveValues(
-    GraphQLStreamDirective,
-    fieldNodes[0],
-    exeContext.variableValues,
-  );
-
-  if (!stream) {
-    return;
-  }
-
-  if (stream.if === false) {
-    return;
-  }
-
-  invariant(
-    typeof stream.initialCount === 'number',
-    'initialCount must be a number',
-  );
-
-  invariant(
-    stream.initialCount >= 0,
-    'initialCount must be a positive integer',
-  );
-
-  return {
-    initialCount: stream.initialCount,
-    label: typeof stream.label === 'string' ? stream.label : undefined,
-  };
-}
 
   /**
    * Complete an iterator value by completing each result.

--- a/src/execution/executor.ts
+++ b/src/execution/executor.ts
@@ -1072,50 +1072,54 @@ export class Executor {
     );
   }
 
-  /**
-   * Returns an object containing the `@stream` arguments if a field should be
-   * streamed based on the experimental flag, stream directive present and
-   * not disabled by the "if" argument.
-   */
-  getStreamValues(
-    exeContext: ExecutionContext,
-    fieldNodes: ReadonlyArray<FieldNode>,
-  ):
-    | undefined
-    | {
-        initialCount?: number;
-        label?: string;
-      } {
-    if (exeContext.disableIncremental) {
-      return;
-    }
-
-    // validation only allows equivalent streams on multiple fields, so it is
-    // safe to only check the first fieldNode for the stream directive
-    const stream = getDirectiveValues(
-      GraphQLStreamDirective,
-      fieldNodes[0],
-      exeContext.variableValues,
-    );
-
-    if (!stream) {
-      return;
-    }
-
-    if (stream.if === false) {
-      return;
-    }
-
-    return {
-      initialCount:
-        // initialCount is required number argument
-        /* c8 ignore next 3 */
-        typeof stream.initialCount === 'number'
-          ? stream.initialCount
-          : undefined,
-      label: typeof stream.label === 'string' ? stream.label : undefined,
-    };
+/**
+ * Returns an object containing the `@stream` arguments if a field should be
+ * streamed based on the experimental flag, stream directive present and
+ * not disabled by the "if" argument.
+ */
+ getStreamValues(
+  exeContext: ExecutionContext,
+  fieldNodes: ReadonlyArray<FieldNode>,
+):
+  | undefined
+  | {
+      initialCount?: number;
+      label?: string;
+    } {
+  if (exeContext.disableIncremental) {
+    return;
   }
+  // validation only allows equivalent streams on multiple fields, so it is
+  // safe to only check the first fieldNode for the stream directive
+  const stream = getDirectiveValues(
+    GraphQLStreamDirective,
+    fieldNodes[0],
+    exeContext.variableValues,
+  );
+
+  if (!stream) {
+    return;
+  }
+
+  if (stream.if === false) {
+    return;
+  }
+
+  invariant(
+    typeof stream.initialCount === 'number',
+    'initialCount must be a number',
+  );
+
+  invariant(
+    stream.initialCount >= 0,
+    'initialCount must be a positive integer',
+  );
+
+  return {
+    initialCount: stream.initialCount,
+    label: typeof stream.label === 'string' ? stream.label : undefined,
+  };
+}
 
   /**
    * Complete an iterator value by completing each result.

--- a/src/validation/__tests__/DeferStreamDirectiveOnRootFieldRule-test.ts
+++ b/src/validation/__tests__/DeferStreamDirectiveOnRootFieldRule-test.ts
@@ -1,0 +1,258 @@
+import { describe, it } from 'mocha';
+
+import { buildSchema } from 'graphql';
+
+import { DeferStreamDirectiveOnRootFieldRule } from '../rules/DeferStreamDirectiveOnRootFieldRule';
+
+import { expectValidationErrorsWithSchema } from './harness';
+
+function expectErrors(queryStr: string) {
+  return expectValidationErrorsWithSchema(
+    schema,
+    DeferStreamDirectiveOnRootFieldRule,
+    queryStr,
+  );
+}
+
+function expectValid(queryStr: string) {
+  expectErrors(queryStr).toDeepEqual([]);
+}
+
+const schema = buildSchema(`
+  type Message {
+    body: String
+    sender: String
+  }
+
+  type SubscriptionRoot {
+    subscriptionField: Message
+    subscriptionListField: [Message]
+  }
+
+  type MutationRoot {
+    mutationField: Message
+    mutationListField: [Message]
+  }
+
+  type QueryRoot {
+    message: Message
+    messages: [Message]
+  }
+
+  schema {
+    query: QueryRoot
+    mutation: MutationRoot
+    subscription: SubscriptionRoot
+  }
+`);
+
+describe('Validate: Defer/Stream directive on root field', () => {
+  it('Defer fragment spread on root query field', () => {
+    expectValid(`
+      {
+        ...rootQueryFragment @defer
+      }
+      fragment rootQueryFragment on QueryRoot {
+        message {
+          body
+        }
+      }
+    `);
+  });
+
+  it('Defer inline fragment spread on root query field', () => {
+    expectValid(`
+      {
+        ... @defer {
+          message {
+            body
+          }
+        }
+      }
+    `);
+  });
+
+  it('Defer fragment spread on root mutation field', () => {
+    expectErrors(`
+      mutation {
+        ...rootFragment @defer
+      }
+      fragment rootFragment on MutationRoot {
+        mutationField {
+          body
+        }
+      }
+    `).toDeepEqual([
+      {
+        message:
+          'Defer directive cannot be used on root mutation type "MutationRoot".',
+        locations: [{ line: 3, column: 25 }],
+      },
+    ]);
+  });
+  it('Defer inline fragment spread on root mutation field', () => {
+    expectErrors(`
+      mutation {
+        ... @defer {
+          mutationField {
+            body
+          }
+        }
+      }
+    `).toDeepEqual([
+      {
+        message:
+          'Defer directive cannot be used on root mutation type "MutationRoot".',
+        locations: [{ line: 3, column: 13 }],
+      },
+    ]);
+  });
+
+  it('Defer fragment spread on nested mutation field', () => {
+    expectValid(`
+      mutation {
+        mutationField {
+          ... @defer {
+            body
+          }
+        }
+      }
+    `);
+  });
+
+  it('Defer fragment spread on root subscription field', () => {
+    expectErrors(`
+      subscription {
+        ...rootFragment @defer
+      }
+      fragment rootFragment on SubscriptionRoot {
+        subscriptionField {
+          body
+        }
+      }
+    `).toDeepEqual([
+      {
+        message:
+          'Defer directive cannot be used on root subscription type "SubscriptionRoot".',
+        locations: [{ line: 3, column: 25 }],
+      },
+    ]);
+  });
+  it('Defer inline fragment spread on root subscription field', () => {
+    expectErrors(`
+      subscription {
+        ... @defer {
+          subscriptionField {
+            body
+          }
+        }
+      }
+    `).toDeepEqual([
+      {
+        message:
+          'Defer directive cannot be used on root subscription type "SubscriptionRoot".',
+        locations: [{ line: 3, column: 13 }],
+      },
+    ]);
+  });
+
+  it('Defer fragment spread on nested subscription field', () => {
+    expectValid(`
+      subscription {
+        subscriptionField {
+          ...nestedFragment
+        }
+      }
+      fragment nestedFragment on Message {
+        body
+      }
+    `);
+  });
+  it('Stream field on root query field', () => {
+    expectValid(`
+      {
+        messages @stream {
+          name
+        }
+      }
+    `);
+  });
+  it('Stream field on fragment on root query field', () => {
+    expectValid(`
+      {
+        ...rootFragment
+      }
+      fragment rootFragment on QueryType {
+        messages @stream {
+          name
+        }
+      }
+    `);
+  });
+  it('Stream field on root mutation field', () => {
+    expectErrors(`
+      mutation {
+        mutationListField @stream {
+          name
+        }
+      }
+    `).toDeepEqual([
+      {
+        message:
+          'Stream directive cannot be used on root mutation type "MutationRoot".',
+        locations: [{ line: 3, column: 27 }],
+      },
+    ]);
+  });
+  it('Stream field on fragment on root mutation field', () => {
+    expectErrors(`
+      mutation {
+        ...rootFragment
+      }
+      fragment rootFragment on MutationRoot {
+        mutationListField @stream {
+          name
+        }
+      }
+    `).toDeepEqual([
+      {
+        message:
+          'Stream directive cannot be used on root mutation type "MutationRoot".',
+        locations: [{ line: 6, column: 27 }],
+      },
+    ]);
+  });
+  it('Stream field on root subscription field', () => {
+    expectErrors(`
+      subscription {
+        subscriptionListField @stream {
+          name
+        }
+      }
+    `).toDeepEqual([
+      {
+        message:
+          'Stream directive cannot be used on root subscription type "SubscriptionRoot".',
+        locations: [{ line: 3, column: 31 }],
+      },
+    ]);
+  });
+  it('Stream field on fragment on root subscription field', () => {
+    expectErrors(`
+      subscription {
+        ...rootFragment
+      }
+      fragment rootFragment on SubscriptionRoot {
+        subscriptionListField @stream {
+          name
+        }
+      }
+    `).toDeepEqual([
+      {
+        message:
+          'Stream directive cannot be used on root subscription type "SubscriptionRoot".',
+        locations: [{ line: 6, column: 31 }],
+      },
+    ]);
+  });
+});

--- a/src/validation/__tests__/StreamDirectiveOnListFieldRule-test.ts
+++ b/src/validation/__tests__/StreamDirectiveOnListFieldRule-test.ts
@@ -23,6 +23,16 @@ describe('Validate: Stream directive on list field', () => {
     `);
   });
 
+  it('Stream on non-null list field', () => {
+    expectValid(`
+      fragment objectFieldSelection on Human {
+        relatives @stream(initialCount: 0) {
+          name
+        }
+      }
+    `);
+  });
+
   it("Doesn't validate other directives on list fields", () => {
     expectValid(`
     fragment objectFieldSelection on Human {

--- a/src/validation/__tests__/harness.ts
+++ b/src/validation/__tests__/harness.ts
@@ -50,7 +50,7 @@ export const testSchema: GraphQLSchema = buildSchema(`
   type Human {
     name(surname: Boolean): String
     pets: [Pet]
-    relatives: [Human]
+    relatives: [Human]!
   }
 
   enum FurColor {

--- a/src/validation/index.ts
+++ b/src/validation/index.ts
@@ -1,3 +1,6 @@
+// Spec Section (with defer/stream support): "Defer And Stream Directives Are Used On Valid Root Field"
+export { DeferStreamDirectiveOnRootFieldRule } from './rules/DeferStreamDirectiveOnRootFieldRule';
+
 /** Spec Section (with defer/stream support): "Field Selection Merging" */
 export { OverlappingFieldsCanBeMergedRule } from './rules/OverlappingFieldsCanBeMergedRule';
 

--- a/src/validation/rules/DeferStreamDirectiveOnRootFieldRule.ts
+++ b/src/validation/rules/DeferStreamDirectiveOnRootFieldRule.ts
@@ -1,0 +1,61 @@
+import { GraphQLError } from 'graphql';
+
+import type { ASTVisitor, ValidationContext } from 'graphql';
+
+import {
+  GraphQLDeferDirective,
+  GraphQLStreamDirective,
+} from '../../type/directives';
+
+/**
+ * Stream directive on list field
+ *
+ * A GraphQL document is only valid if defer directives are not used on root mutation or subscription types.
+ */
+export function DeferStreamDirectiveOnRootFieldRule(
+  context: ValidationContext,
+): ASTVisitor {
+  return {
+    Directive(node) {
+      const mutationType = context.getSchema().getMutationType();
+      const subscriptionType = context.getSchema().getSubscriptionType();
+      const parentType = context.getParentType();
+      if (parentType && node.name.value === GraphQLDeferDirective.name) {
+        if (mutationType && parentType === mutationType) {
+          context.reportError(
+            new GraphQLError(
+              `Defer directive cannot be used on root mutation type "${parentType.name}".`,
+              node,
+            ),
+          );
+        }
+        if (subscriptionType && parentType === subscriptionType) {
+          context.reportError(
+            new GraphQLError(
+              `Defer directive cannot be used on root subscription type "${parentType.name}".`,
+              node,
+            ),
+          );
+        }
+      }
+      if (parentType && node.name.value === GraphQLStreamDirective.name) {
+        if (mutationType && parentType === mutationType) {
+          context.reportError(
+            new GraphQLError(
+              `Stream directive cannot be used on root mutation type "${parentType.name}".`,
+              node,
+            ),
+          );
+        }
+        if (subscriptionType && parentType === subscriptionType) {
+          context.reportError(
+            new GraphQLError(
+              `Stream directive cannot be used on root subscription type "${parentType.name}".`,
+              node,
+            ),
+          );
+        }
+      }
+    },
+  };
+}

--- a/src/validation/rules/OverlappingFieldsCanBeMergedRule.ts
+++ b/src/validation/rules/OverlappingFieldsCanBeMergedRule.ts
@@ -650,14 +650,14 @@ function sameDirectiveArgument(
   directive2: DirectiveNode,
   argumentName: string,
 ): boolean {
-  // See https://github.com/graphql/graphql-js/issues/2203
+  // FIXME https://github.com/graphql/graphql-js/issues/2203
   const args1 = /* c8 ignore next */ directive1.arguments ?? [];
   const arg1 = args1.find((argument) => argument.name.value === argumentName);
   if (!arg1) {
     return false;
   }
 
-  // See https://github.com/graphql/graphql-js/issues/2203
+  // FIXME https://github.com/graphql/graphql-js/issues/2203
   const args2 = /* c8 ignore next */ directive2.arguments ?? [];
   const arg2 = args2.find((argument) => argument.name.value === argumentName);
   if (!arg2) {

--- a/src/validation/rules/StreamDirectiveOnListFieldRule.ts
+++ b/src/validation/rules/StreamDirectiveOnListFieldRule.ts
@@ -1,5 +1,5 @@
 import type { ASTVisitor, DirectiveNode, ValidationContext } from 'graphql';
-import { GraphQLError, isListType } from 'graphql';
+import { GraphQLError, isListType, isWrappingType } from 'graphql';
 
 import { GraphQLStreamDirective } from '../../type/directives';
 
@@ -19,7 +19,10 @@ export function StreamDirectiveOnListFieldRule(
         fieldDef &&
         parentType &&
         node.name.value === GraphQLStreamDirective.name &&
-        !isListType(fieldDef.type)
+        !(
+          isListType(fieldDef.type) ||
+          (isWrappingType(fieldDef.type) && isListType(fieldDef.type.ofType))
+        )
       ) {
         context.reportError(
           new GraphQLError(


### PR DESCRIPTION
Highlights of latest upstream changes made by @robrichard include:
= new rules for disabling defer/stream on non-query root fields
= field error on negative initialCount

This change also better aligns graphql-executor tests to graphql-js, favoring upstream code/tests of similar functionality rather than the original tests within graphql-executor. Differences are mostly around payload ordering.

Similarly, some style differences are normalized; except we still us expect rather than expectJSON when expectJSON is not necessary (no errors).