### PR TITLE
Do not validate schema on first execution

### DIFF
--- a/.changeset/thirty-monkeys-fail.md
+++ b/.changeset/thirty-monkeys-fail.md
@@ -1,0 +1,11 @@
+---
+'graphql-executor': patch
+---
+
+Skip schema validation prior to first use.
+
+Schemas can (and should!) still be validated when and where appropriate using the dedicated graphql-js validateSchema method.
+
+graphql-js validates previously unvalidated schemas prior to the first execution. The validation step is skipped by graphql-js if and only if the schema was created with the `assumeValid` option, which essentially triggers a faux validation run that produces no errors.
+
+graphql-executor now simply does not automatically validate schemas, preferring to require servers to explicitly validate schemas when and where appropriate, just as document validation is a distinct, explicit step.

--- a/src/execution/executor.ts
+++ b/src/execution/executor.ts
@@ -21,7 +21,6 @@ import {
   SchemaMetaFieldDef,
   TypeMetaFieldDef,
   TypeNameMetaFieldDef,
-  assertValidSchema,
   getOperationRootType,
   isObjectType,
   isAbstractType,
@@ -50,6 +49,8 @@ import { isAsyncIterable } from '../jsutils/isAsyncIterable';
 import { isIterableObject } from '../jsutils/isIterableObject';
 import { resolveAfterAll } from '../jsutils/resolveAfterAll';
 import { Repeater } from '../jsutils/repeater';
+
+import { assertSchema } from '../type/schema';
 
 import {
   getVariableValues,
@@ -442,8 +443,8 @@ export class Executor {
   ): void {
     devAssert(document, 'Must provide document.');
 
-    // If the schema used for execution is invalid, throw an error.
-    assertValidSchema(schema);
+    // Schema must be provided.
+    assertSchema(schema);
 
     // Variables, if provided, must be an object.
     devAssert(

--- a/src/type/schema.ts
+++ b/src/type/schema.ts
@@ -1,0 +1,11 @@
+import type { GraphQLSchema } from 'graphql';
+import { isSchema } from 'graphql';
+
+import { inspect } from '../jsutils/inspect';
+
+export function assertSchema(schema: GraphQLSchema): GraphQLSchema {
+  if (!isSchema(schema)) {
+    throw new Error(`Expected ${inspect(schema)} to be a GraphQL schema.`);
+  }
+  return schema;
+}


### PR DESCRIPTION
Schemas can still be validated when desired using the dedicated validateSchema, which should usually be done as a separate step to avoid unnecessary revalidation.

Previously, by default, on first execution, a schema would be validated (if not validated already). This behavior could be disabled by using the assumeValid option with schema creation.