### PR TITLE
allow type resolution with GraphQLObjectTypes

### DIFF
--- a/src/execution/executor.ts
+++ b/src/execution/executor.ts
@@ -52,6 +52,7 @@ import {
   isAbstractType,
   isLeafType,
   isListType,
+  isNamedType,
   isNonNullType,
   isObjectType,
 } from '../type/definition';
@@ -1439,31 +1440,24 @@ export class Executor {
   }
 
   ensureValidRuntimeType(
-    runtimeTypeName: unknown,
+    runtimeTypeOrName: unknown,
     exeContext: ExecutionContext,
     returnType: GraphQLAbstractType,
     fieldNodes: ReadonlyArray<FieldNode>,
     info: GraphQLResolveInfo,
     result: unknown,
   ): GraphQLObjectType {
-    if (runtimeTypeName == null) {
+    if (runtimeTypeOrName == null) {
       throw new GraphQLError(
         `Abstract type "${returnType.name}" must resolve to an Object type at runtime for field "${info.parentType.name}.${info.fieldName}". Either the "${returnType.name}" type should provide a "resolveType" function or each possible type should provide an "isTypeOf" function.`,
         fieldNodes,
       );
     }
 
-    // releases before 16.0.0 supported returning `GraphQLObjectType` from `resolveType`
-    // TODO: remove in 17.0.0 release
-    if (
-      typeof runtimeTypeName === 'object' &&
-      runtimeTypeName &&
-      isObjectType(runtimeTypeName)
-    ) {
-      throw new GraphQLError(
-        'Support for returning GraphQLObjectType from resolveType was removed in graphql-js@16.0.0 please return type name instead.',
-      );
-    }
+    const runtimeTypeName =
+      typeof runtimeTypeOrName === 'object' && isNamedType(runtimeTypeOrName)
+        ? runtimeTypeOrName.name
+        : runtimeTypeOrName;
 
     if (typeof runtimeTypeName !== 'string') {
       throw new GraphQLError(

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ export {
   isEnumType,
   isInputObjectType,
   isListType,
+  isNamedType,
   isNonNullType,
   isInputType,
   isLeafType,

--- a/src/type/definition.ts
+++ b/src/type/definition.ts
@@ -6,6 +6,7 @@ import type {
   GraphQLInterfaceType,
   GraphQLLeafType,
   GraphQLList,
+  GraphQLNamedType,
   GraphQLNonNull,
   GraphQLNullableType,
   GraphQLObjectType,
@@ -148,3 +149,17 @@ function _isWrappingType(type: { [key: string]: any }) {
 export const isWrappingType = memoize1(_isWrappingType) as (type: {
   [key: string]: any;
 }) => type is GraphQLWrappingType;
+
+function _isNamedType(type: { [key: string]: any }) {
+  return (
+    isScalarType(type) ||
+    isObjectType(type) ||
+    isInterfaceType(type) ||
+    isUnionType(type) ||
+    isEnumType(type) ||
+    isInputObjectType(type)
+  );
+}
+export const isNamedType = memoize1(_isNamedType) as (type: {
+  [key: string]: any;
+}) => type is GraphQLNamedType;

--- a/src/type/index.ts
+++ b/src/type/index.ts
@@ -14,6 +14,7 @@ export {
   isEnumType,
   isInputObjectType,
   isListType,
+  isNamedType,
   isNonNullType,
   isInputType,
   isLeafType,


### PR DESCRIPTION
...as opposed to just type names.

This reverts graphql#2905

This change was made upstream to support schema transformation functions like lexicographicallySortSchema which do not modify resolveType methods. Previously, a workaround was included that simply looks up the actual type from the type name returned by resolveType. In actuality, in my opinion, the schema transformation functions should natively or manually modify the resolveType function so it works correctly.

In any case, we restore the workaround here to preserve v14 support.