### PR TITLE
add all possible input types to ExecutorSchema

### DIFF
--- a/.changeset/famous-insects-reflect.md
+++ b/.changeset/famous-insects-reflect.md
@@ -1,0 +1,7 @@
+---
+'graphql-executor': patch
+---
+
+Add all valid input types to ExecutorSchema
+
+Variables can define ad-hoc input types not present in schema by adding non-null wrappers.

--- a/src/execution/toExecutorSchema.ts
+++ b/src/execution/toExecutorSchema.ts
@@ -13,12 +13,12 @@ import type {
   GraphQLType,
   GraphQLNullableType,
   GraphQLOutputType,
-  GraphQLList,
-  GraphQLNonNull,
   OperationTypeNode,
   TypeNode,
 } from 'graphql';
 import {
+  GraphQLList,
+  GraphQLNonNull,
   Kind,
   SchemaMetaFieldDef,
   TypeMetaFieldDef,
@@ -124,6 +124,10 @@ class TypeTree {
     return this._get(typeNode, this._rootNode);
   }
 
+  has(typeString: string): boolean {
+    return this.typeStrings.has(typeString);
+  }
+
   private _get(
     typeNode: TypeNode,
     node: TypeTreeNode,
@@ -177,6 +181,27 @@ class TypeTree {
       node[Kind.NAMED_TYPE].set((type as GraphQLNamedType).name, originalType);
     }
   }
+}
+
+function getPossibleInputTypes(
+  type: GraphQLInputType,
+): Array<GraphQLInputType> {
+  if (_isListType(type)) {
+    return [
+      ...getPossibleInputTypes(type.ofType).map(
+        (possibleType) => new GraphQLList(possibleType),
+      ),
+      ...getPossibleInputTypes(type.ofType).map(
+        (possibleType) => new GraphQLNonNull(new GraphQLList(possibleType)),
+      ),
+    ];
+  }
+
+  if (_isNonNullType(type)) {
+    return [...getPossibleInputTypes(type.ofType)];
+  }
+
+  return [new GraphQLNonNull(type), type];
 }
 
 function _toExecutorSchema(schema: GraphQLSchema): ExecutorSchema {
@@ -329,6 +354,18 @@ function _toExecutorSchema(schema: GraphQLSchema): ExecutorSchema {
       inputTypes.add(arg.type);
       addInputType(arg.type);
       processType(arg.type);
+    }
+  }
+
+  // add all possible input types to schema
+  // as variables can add non-null wrappers to input types defined in schema
+  for (const inputType of inputTypes.values()) {
+    const possibleInputTypes = getPossibleInputTypes(inputType);
+    for (const possibleInputType of possibleInputTypes) {
+      const typeString = possibleInputType.toString();
+      if (!typeTree.has(typeString)) {
+        addInputType(possibleInputType);
+      }
     }
   }
 


### PR DESCRIPTION
as variables can add non-null wrappers to input types defined in the schema