### PR TITLE
revisit fragments if visited initially with defer

### DIFF
--- a/.changeset/red-otters-share.md
+++ b/.changeset/red-otters-share.md
@@ -1,0 +1,9 @@
+---
+'graphql-executor': patch
+---
+
+Revisit fragments if visited initially with `@defer`
+
+Fragments visited previously with `@defer` have not been added to the initial group field set, and so must be added.
+
+See: https://github.com/robrichard/defer-stream-wg/discussions/29#discussioncomment-2099307

--- a/src/execution/executor.ts
+++ b/src/execution/executor.ts
@@ -2594,7 +2594,6 @@ export class Executor {
           ) {
             continue;
           }
-          visitedFragmentNames.add(fragName);
 
           if (defer) {
             const patchFields = new Map();
@@ -2613,6 +2612,8 @@ export class Executor {
               fields: patchFields,
             });
           } else {
+            visitedFragmentNames.add(fragName);
+
             this.collectFieldsImpl(
               fragments,
               variableValues,


### PR DESCRIPTION
...because they have to be added to the initial grouped field selection set

See: https://github.com/robrichard/defer-stream-wg/discussions/29#discussioncomment-2099307