### PR TITLE
limit when `data` property is an array

### DIFF
--- a/.changeset/giant-llamas-peel.md
+++ b/.changeset/giant-llamas-peel.md
@@ -5,5 +5,3 @@
 introduce experimental parallel streaming
 
 Experimental `inParallel` boolean argument to the stream directive may now be used to stream list items as they are ready instead of in sequential list order.
-
-When parallel streaming is enabled, the `data` property of execution patch results will consist of an array of items and a new `atIndices` property will contain the corresponding indices of the items.

--- a/.changeset/thin-maps-boil.md
+++ b/.changeset/thin-maps-boil.md
@@ -6,6 +6,4 @@ introduce experimental batched streaming
 
 Experimental `maxChunkSize` and `maxInterval` arguments allows for increasing the number of items in each streamed payload up to the specified maximum size. A maximum interval (specified in milliseconds) can be used to send any ready items prior to the maximum chunk size.
 
-When using a `maxChunkSize` greater than 1, the `data` property of execution patch results will consist of an array of items and a new `atIndex` property will contain the initial index for the items included within the chunk.
-
-These options can be combined with parallel streaming. When streaming in parallel, the `data` property will always consist on an array of items and the `atIndices` property will always consist of an array of the matching indices, even when `maxChunkSize` is equal to 1. If these new arguments prove popular, `data` should probably be an array even when `maxChunkSize` is equal to one, even without parallel streaming.
+When using a `maxChunkSize` greater than 1, the `data` property of execution patch results will consist of an array of items and a new `atIndex` property will contain the initial index for the items included within the chunk. When streaming in parallel, new `atIndices` property will be used instead of `atIndex` and withh contain an array of the corresponding indices for each of the items included within the `data` property.

--- a/src/execution/executor.ts
+++ b/src/execution/executor.ts
@@ -138,21 +138,26 @@ interface BundlerInterface {
   setTotal: (total: number) => void;
 }
 
-interface SequentialStreamResponseContext extends SubsequentResponseContext {
+interface StreamResponseContext extends SubsequentResponseContext {
   atIndex: number;
 }
 
-interface ParallelStreamResponseContext extends SubsequentResponseContext {
+interface BatchedParallelStreamResponseContext
+  extends SubsequentResponseContext {
   atIndices: Array<number>;
 }
 
-interface SequentialStreamDataBundleContext
-  extends SequentialStreamResponseContext {
+interface StreamDataBundleContext extends StreamResponseContext {
+  result: unknown;
+}
+
+interface BatchedSequentialStreamDataBundleContext
+  extends StreamResponseContext {
   results: Array<unknown>;
 }
 
-interface ParallelStreamDataBundleContext
-  extends ParallelStreamResponseContext {
+interface BatchedParallelStreamDataBundleContext
+  extends BatchedParallelStreamResponseContext {
   results: Array<unknown>;
 }
 
@@ -1504,203 +1509,219 @@ export class Executor {
     label: string | undefined,
     parentResponseNode: ResponseNode,
   ): StreamContext {
+    if (maxChunkSize === 1) {
+      const bundler = new Bundler<
+        StreamDataResult,
+        ResponseNode,
+        StreamDataBundleContext,
+        StreamResponseContext
+      >({
+        initialIndex: initialCount,
+        maxBundleSize: maxChunkSize,
+        maxInterval,
+        createDataBundleContext: (index, result) => {
+          exeContext.state.pendingPushes++;
+          exeContext.state.pendingStreamResults--;
+          return {
+            responseNodes: [result.responseNode],
+            parentResponseNode,
+            result: result.data,
+            atIndex: index,
+          };
+        },
+        createErrorBundleContext: (index, responseNode) => {
+          exeContext.state.pendingPushes++;
+          exeContext.state.pendingStreamResults--;
+          return {
+            responseNodes: [responseNode],
+            parentResponseNode,
+            atIndex: index,
+          };
+        } /* c8 ignore start */,
+        onSubsequentData: () => {
+          /* with maxBundleSize of 1, this function will never be called */
+        },
+        onSubsequentError: () => {
+          /* with maxBundleSize of 1, this function will never be called */
+        } /* c8 ignore stop */,
+        onDataBundle: (context) => {
+          exeContext.publisher.queue(
+            context.responseNodes,
+            {
+              responseContext: context,
+              data: context.result,
+              path: addPath(path, context.atIndex, undefined),
+              label,
+            },
+            parentResponseNode,
+          );
+        },
+        onErrorBundle: (context) => {
+          exeContext.publisher.queue(
+            context.responseNodes,
+            {
+              responseContext: context,
+              data: null,
+              path: addPath(path, context.atIndex, undefined),
+              label,
+            },
+            parentResponseNode,
+          );
+        },
+      });
+
+      return {
+        initialCount,
+        path,
+        bundler: inParallel
+          ? bundler
+          : getSequentialBundler(initialCount, bundler),
+      };
+    }
+
+    if (inParallel) {
+      return {
+        initialCount,
+        path,
+        bundler: new Bundler<
+          StreamDataResult,
+          ResponseNode,
+          BatchedParallelStreamDataBundleContext,
+          BatchedParallelStreamResponseContext
+        >({
+          initialIndex: initialCount,
+          maxBundleSize: maxChunkSize,
+          maxInterval,
+          createDataBundleContext: (index, result) => {
+            exeContext.state.pendingPushes++;
+            exeContext.state.pendingStreamResults--;
+            return {
+              responseNodes: [result.responseNode],
+              parentResponseNode,
+              atIndices: [index],
+              results: [result.data],
+            };
+          },
+          createErrorBundleContext: (index, responseNode) => {
+            exeContext.state.pendingPushes++;
+            exeContext.state.pendingStreamResults--;
+            return {
+              responseNodes: [responseNode],
+              parentResponseNode,
+              atIndices: [index],
+            };
+          },
+          onSubsequentData: (index, result, context) => {
+            exeContext.state.pendingStreamResults--;
+            context.responseNodes.push(result.responseNode);
+            context.results.push(result.data);
+            context.atIndices.push(index);
+          },
+          onSubsequentError: (index, responseNode, context) => {
+            exeContext.state.pendingStreamResults--;
+            context.responseNodes.push(responseNode);
+            context.atIndices.push(index);
+          },
+          onDataBundle: (context) => {
+            exeContext.publisher.queue(
+              context.responseNodes,
+              {
+                responseContext: context,
+                data: context.results,
+                path,
+                atIndices: context.atIndices,
+                label,
+              },
+              parentResponseNode,
+            );
+          },
+          onErrorBundle: (context) => {
+            exeContext.publisher.queue(
+              context.responseNodes,
+              {
+                responseContext: context,
+                data: null,
+                path,
+                atIndices: context.atIndices,
+                label,
+              },
+              parentResponseNode,
+            );
+          },
+        }),
+      };
+    }
+
     return {
       initialCount,
       path,
-      bundler: inParallel
-        ? new Bundler<
-            StreamDataResult,
-            ResponseNode,
-            ParallelStreamDataBundleContext,
-            ParallelStreamResponseContext
-          >({
-            initialIndex: initialCount,
-            maxBundleSize: maxChunkSize,
-            maxInterval,
-            createDataBundleContext: () => {
-              exeContext.state.pendingPushes++;
-              return {
-                responseNodes: [],
-                parentResponseNode,
-                atIndices: [],
-                results: [],
-              };
-            },
-            createErrorBundleContext: () => {
-              exeContext.state.pendingPushes++;
-              return {
-                responseNodes: [],
-                parentResponseNode,
-                atIndices: [],
-              };
-            },
-            onData: (index, result, context) => {
-              exeContext.state.pendingStreamResults--;
-              context.responseNodes.push(result.responseNode);
-              context.results.push(result.data);
-              context.atIndices.push(index);
-            },
-            onError: (index, responseNode, context) => {
-              exeContext.state.pendingStreamResults--;
-              context.responseNodes.push(responseNode);
-              context.atIndices.push(index);
-            },
-            onDataBundle: (context) => {
-              exeContext.publisher.queue(
-                context.responseNodes,
-                {
-                  responseContext: context,
-                  data: context.results,
-                  path,
-                  atIndices: context.atIndices,
-                  label,
-                },
-                parentResponseNode,
-              );
-            },
-            onErrorBundle: (context) => {
-              exeContext.publisher.queue(
-                context.responseNodes,
-                {
-                  responseContext: context,
-                  data: null,
-                  path,
-                  atIndices: context.atIndices,
-                  label,
-                },
-                parentResponseNode,
-              );
-            },
-          })
-        : maxChunkSize > 1
-        ? getSequentialBundler(
-            initialCount,
-            new Bundler<
-              StreamDataResult,
-              ResponseNode,
-              SequentialStreamDataBundleContext,
-              SequentialStreamResponseContext
-            >({
-              initialIndex: initialCount,
-              maxBundleSize: maxChunkSize,
-              maxInterval,
-              createDataBundleContext: (count) => {
-                exeContext.state.pendingPushes++;
-                return {
-                  responseNodes: [],
-                  parentResponseNode,
-                  atIndex: count,
-                  results: [],
-                };
+      bundler: getSequentialBundler(
+        initialCount,
+        new Bundler<
+          StreamDataResult,
+          ResponseNode,
+          BatchedSequentialStreamDataBundleContext,
+          StreamResponseContext
+        >({
+          initialIndex: initialCount,
+          maxBundleSize: maxChunkSize,
+          maxInterval,
+          createDataBundleContext: (index, result) => {
+            exeContext.state.pendingPushes++;
+            exeContext.state.pendingStreamResults--;
+            return {
+              responseNodes: [],
+              parentResponseNode,
+              atIndex: index,
+              results: [result.data],
+            };
+          },
+          createErrorBundleContext: (index, responseNode) => {
+            exeContext.state.pendingPushes++;
+            exeContext.state.pendingStreamResults--;
+            return {
+              responseNodes: [responseNode],
+              parentResponseNode,
+              atIndex: index,
+            };
+          },
+          onSubsequentData: (_index, result, context) => {
+            exeContext.state.pendingStreamResults--;
+            context.responseNodes.push(result.responseNode);
+            context.results.push(result.data);
+          },
+          onSubsequentError: (_index, responseNode, context) => {
+            exeContext.state.pendingStreamResults--;
+            context.responseNodes.push(responseNode);
+          },
+          onDataBundle: (context) => {
+            exeContext.publisher.queue(
+              context.responseNodes,
+              {
+                responseContext: context,
+                data: context.results,
+                path,
+                atIndex: context.atIndex,
+                label,
               },
-              createErrorBundleContext: (count) => {
-                exeContext.state.pendingPushes++;
-                return {
-                  responseNodes: [],
-                  parentResponseNode,
-                  atIndex: count,
-                };
+              parentResponseNode,
+            );
+          },
+          onErrorBundle: (context) => {
+            exeContext.publisher.queue(
+              context.responseNodes,
+              {
+                responseContext: context,
+                data: null,
+                path,
+                atIndex: context.atIndex,
+                label,
               },
-              onData: (_index, result, context) => {
-                exeContext.state.pendingStreamResults--;
-                context.responseNodes.push(result.responseNode);
-                context.results.push(result.data);
-              },
-              onError: (_index, responseNode, context) => {
-                exeContext.state.pendingStreamResults--;
-                context.responseNodes.push(responseNode);
-              },
-              onDataBundle: (context) => {
-                exeContext.publisher.queue(
-                  context.responseNodes,
-                  {
-                    responseContext: context,
-                    data: context.results,
-                    path,
-                    atIndex: context.atIndex,
-                    label,
-                  },
-                  parentResponseNode,
-                );
-              },
-              onErrorBundle: (context) => {
-                exeContext.publisher.queue(
-                  context.responseNodes,
-                  {
-                    responseContext: context,
-                    data: null,
-                    path,
-                    atIndex: context.atIndex,
-                    label,
-                  },
-                  parentResponseNode,
-                );
-              },
-            }),
-          )
-        : getSequentialBundler(
-            initialCount,
-            new Bundler<
-              StreamDataResult,
-              ResponseNode,
-              SequentialStreamDataBundleContext,
-              SequentialStreamResponseContext
-            >({
-              initialIndex: initialCount,
-              maxBundleSize: maxChunkSize,
-              maxInterval,
-              createDataBundleContext: (count) => {
-                exeContext.state.pendingPushes++;
-                return {
-                  responseNodes: [],
-                  parentResponseNode,
-                  atIndex: count,
-                  results: [],
-                };
-              },
-              createErrorBundleContext: (count) => {
-                exeContext.state.pendingPushes++;
-                return {
-                  responseNodes: [],
-                  parentResponseNode,
-                  atIndex: count,
-                };
-              },
-              onData: (_index, result, context) => {
-                exeContext.state.pendingStreamResults--;
-                context.responseNodes.push(result.responseNode);
-                context.results.push(result.data);
-              },
-              onError: (_index, responseNode, context) => {
-                exeContext.state.pendingStreamResults--;
-                context.responseNodes.push(responseNode);
-              },
-              onDataBundle: (context) => {
-                exeContext.publisher.queue(
-                  context.responseNodes,
-                  {
-                    responseContext: context,
-                    data: context.results[0],
-                    path: addPath(path, context.atIndex, undefined),
-                    label,
-                  },
-                  parentResponseNode,
-                );
-              },
-              onErrorBundle: (context) => {
-                exeContext.publisher.queue(
-                  context.responseNodes,
-                  {
-                    responseContext: context,
-                    data: null,
-                    path: addPath(path, context.atIndex, undefined),
-                    label,
-                  },
-                  parentResponseNode,
-                );
-              },
-            }),
-          ),
+              parentResponseNode,
+            );
+          },
+        }),
+      ),
     };
   }
 

--- a/src/jsutils/__tests__/bundler-test.ts
+++ b/src/jsutils/__tests__/bundler-test.ts
@@ -22,13 +22,19 @@ function createHarness() {
     initialIndex: 0,
     maxBundleSize: 2,
     maxInterval: 50,
-    createDataBundleContext: () => ({ atIndices: [], results: [] }),
-    createErrorBundleContext: () => ({ atIndices: [], results: [] }),
-    onData: (index, result, context) => {
+    createDataBundleContext: (index, result) => ({
+      atIndices: [index],
+      results: [result],
+    }),
+    createErrorBundleContext: (index, result) => ({
+      atIndices: [index],
+      results: [result],
+    }),
+    onSubsequentData: (index, result, context) => {
       context.atIndices.push(index);
       context.results.push(result);
     },
-    onError: (index, result, context) => {
+    onSubsequentError: (index, result, context) => {
       context.atIndices.push(index);
       context.results.push(result);
     },

--- a/src/jsutils/__tests__/getSequentialBundler-test.ts
+++ b/src/jsutils/__tests__/getSequentialBundler-test.ts
@@ -23,10 +23,18 @@ function createHarness() {
       initialIndex: 0,
       maxBundleSize: 2,
       maxInterval: null,
-      createDataBundleContext: (count) => ({ atIndex: count, results: [] }),
-      createErrorBundleContext: (count) => ({ atIndex: count, results: [] }),
-      onData: (_index, result, context) => context.results.push(result),
-      onError: (_index, result, context) => context.results.push(result),
+      createDataBundleContext: (index, result) => ({
+        atIndex: index,
+        results: [result],
+      }),
+      createErrorBundleContext: (index, result) => ({
+        atIndex: index,
+        results: [result],
+      }),
+      onSubsequentData: (_index, result, context) =>
+        context.results.push(result),
+      onSubsequentError: (_index, result, context) =>
+        context.results.push(result),
       onDataBundle: (context) => {
         dataContext.atIndex = context.atIndex;
         dataContext.results = context.results;


### PR DESCRIPTION
when using `@stream`, the `data` property will be an array only when batching.

when/if graphql-js changes to always send data as an array for streamed results, graphql-executor will do so as well. until then, data will be an array only when necessary, i.e. when batch streaming